### PR TITLE
Use pegomock's new VerifyWasCalledEventually to avoid fixed delays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ endif
 
 init-gotools:
 	go install -mod=readonly github.com/golang/protobuf/protoc-gen-go
-	go install -mod=readonly github.com/petergtz/pegomock/pegomock
+	go install -mod=readonly github.com/petergtz/pegomock/pegomock/...

--- a/agents/command_handler_test.go
+++ b/agents/command_handler_test.go
@@ -136,8 +136,8 @@ func TestStandardCommandHandler_WaitOnAgentCommand(t *testing.T) {
 
 	commandHandler.WaitOnAgentCommand(ctx, agentRunner, runningContext)
 
-	// allow for agent restart delay and call to EnsureRunningState
-	time.Sleep(10 * time.Millisecond)
-
-	agentRunner.VerifyWasCalledOnce().EnsureRunningState(matchers.AnyContextContext(), pegomock.EqBool(false))
+	agentRunner.VerifyWasCalledEventually(
+		pegomock.Once(),
+		10*time.Millisecond,
+	).EnsureRunningState(matchers.AnyContextContext(), pegomock.EqBool(false))
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/onsi/gomega v1.4.2 // indirect
-	github.com/petergtz/pegomock v0.0.0-20180725144810-278dd9bee025
+	github.com/petergtz/pegomock v0.0.0-20181113220348-aabf5ac7e317
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/petergtz/pegomock v0.0.0-20180725144810-278dd9bee025 h1:HdQ49I8p0I6RB+sX7ZMJN9Fu03UZETdwTmVoWOqrGk4=
 github.com/petergtz/pegomock v0.0.0-20180725144810-278dd9bee025/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
+github.com/petergtz/pegomock v0.0.0-20181113220348-aabf5ac7e317 h1:GXNImmbdl7iBoQ+GvUrqzUUZiiPnJKpgKTzHGTZ5gqY=
+github.com/petergtz/pegomock v0.0.0-20181113220348-aabf5ac7e317/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/ingest/telegraf_json_test.go
+++ b/ingest/telegraf_json_test.go
@@ -114,10 +114,10 @@ func TestTelegrafJson_Start(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, written)
 
-			// yield for ingestor's goroutine
-			time.Sleep(500 * time.Millisecond)
-
-			args := mockEgressConnection.VerifyWasCalled(pegomock.Times(tt.totalCount)).
+			args := mockEgressConnection.VerifyWasCalledEventually(
+				pegomock.Times(tt.totalCount),
+				500*time.Millisecond,
+			).
 				PostMetric(matchers.AnyPtrToTelemetryEdgeMetric()).GetAllCapturedArguments()
 
 			require.Len(t, args, tt.totalCount)


### PR DESCRIPTION
Pegomock just added a new feature (https://github.com/petergtz/pegomock/issues/70) that allows for an "eventual" verification of mock calls. This eliminates the need to insert fixed delays to allow sufficient time/processing to elapse. The fixed delays would have create either brittle tests or extraneous time spent in the unit tests.

FYI, used `go get -u github.com/petergtz/pegomock` and it took care of `go.mod` and `go.sum` updates. I also had to use `go install github.com/petergtz/pegomock/...` to pick up the change to the code generator tool.