### PR TITLE
Change snapshot file path to make it more meaningful

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ nfpm:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "SNAPSHOT-{{.Commit}}"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
`goreleaser init` set it to the old version.  Using the new template with ensure these files can't be confused with prod released by having such a similar name, and attaching the commit id helps determine what branch/commit the file actually relates to.