### PR TITLE
Discover xenId label

### DIFF
--- a/config/labels.go
+++ b/config/labels.go
@@ -20,11 +20,19 @@ package config
 
 import (
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"runtime"
+	"strings"
 )
 
+// ComputeLabels reads any labels specified in the config file.
+// It also auto discovers various instance identifiers such as the os type and hostname.
+// If an auto-detected label is also specified in the config file, the config file value will be used.
+// These labels are passed over to the server-side endpoint.
 func ComputeLabels() (map[string]string, error) {
 	labels := make(map[string]string)
 
@@ -32,10 +40,16 @@ func ComputeLabels() (map[string]string, error) {
 	labels["arch"] = runtime.GOARCH
 
 	hostname, err := os.Hostname()
-	if err == nil {
-		labels["hostname"] = hostname
-	} else {
+	if err != nil {
 		return nil, errors.Wrap(err, "unable to determine hostname label")
+	}
+	labels["hostname"] = hostname
+
+	xenId, err := GetXenId()
+	if err != nil {
+		log.WithError(err).Warn("unable to determine xen-id")
+	} else {
+		labels["xen-id"] = xenId
 	}
 
 	configuredLabels := viper.GetStringMapString("labels")
@@ -43,5 +57,80 @@ func ComputeLabels() (map[string]string, error) {
 		labels[k] = v
 	}
 
+	log.WithField("labels", labels).Debug("discovered labels")
+
 	return labels, nil
+}
+
+// GetXenId will try and detect the id of any server running on the xen hypervisor.
+// It adds this id into the list of labels with key "xen-id".
+func GetXenId() (string, error) {
+	xenId, err := GetXenIdFromCloudInit()
+	if err != nil {
+		log.WithError(err).Debug("failed to get xen-id from cloud init")
+		xenId, err = GetXenIdFromXenClient()
+		if err != nil {
+			log.WithError(err).Debug("failed to get xen-id from xen client")
+			return "", err
+		}
+	}
+	return xenId, err
+}
+
+// GetXenIdFromCloudInit attempts to retrieve the xen-id from the instance id file.
+func GetXenIdFromCloudInit() (string, error) {
+	if runtime.GOOS == "windows" {
+		return "", errors.New("cloud init is not supported on windows")
+	}
+	instanceIdPath := "/var/lib/cloud/data/instance-id"
+	data, err := ioutil.ReadFile(instanceIdPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read from instance id path")
+	}
+	// remove new line characters
+	xenId := strings.TrimSuffix(string(data), "\n")
+	// the fallback datasource is iid-datasource-none when it does not exist
+	// https://cloudinit.readthedocs.io/en/latest/topics/datasources/fallback.html
+	if xenId == "iid-datasource-none" || xenId == "nocloud" {
+		return "", errors.New("invalid instance id found")
+	}
+	return xenId, nil
+}
+
+// GetXenIdFromXenClient attempts to retrieve the xen-id using the xenstore client.
+func GetXenIdFromXenClient() (string, error) {
+	var xenId string
+	switch runtime.GOOS {
+	case "linux":
+		output, err := exec.Command("xenstore-read", "name").Output()
+		if err != nil {
+			return "", err
+		}
+		xenId = string(output)
+	case "windows":
+		file := "c:\\Program Files\\Citrix\\XenTools\\xenstore_client.exe"
+		if _, err := os.Stat(file); os.IsNotExist(err) || err != nil {
+			output, err := exec.Command("powershell", "& {$sid = ((Get-WmiObject -Class CitrixXenStoreBase -Namespace root\\wmi)" +
+				".AddSession(\"Temp\").SessionId) ; $s = (Get-WmiObject -Namespace root\\wmi -Query " +
+				"\"select * from CitrixXenStoreSession where SessionId=$sid\") ; $v = $s.GetValue(\"name\").value ; $s.EndSession() ; $v}",
+				"read", "name").Output()
+			if err != nil {
+				return "", err
+			}
+			xenId = string(output)
+		} else {
+			output, err := exec.Command(file, "name").Output()
+			if err != nil {
+				return "", err
+			}
+			xenId = string(output)
+		}
+	default:
+		return "", errors.New("no xen id found on os with type " + runtime.GOOS)
+	}
+
+	// remove new line characters
+	xenId = strings.TrimSuffix(strings.TrimSuffix(xenId, "\n"), "\r")
+
+	return xenId, nil
 }


### PR DESCRIPTION
For Rackspace cloud servers we will automatically discover the xen id and add it to the list of labels to be sent to the ambassador.

These changes were mostly ported over from the old agent code - https://github.com/virgo-agent-toolkit/virgo-base-agent/blob/master/machineidentity.lua

If a xen id cannot be found, the label will not be used.


## To Do
Still need to figure out the best way to add tests for this.

I have tested manually on cloud servers (ubuntu 18.04, win2k8, win2012) with these results

```
Win2008
m="map[xen-id:instance-d0529bfb-4c09-44a3-86a8-bd8991b03a42 os:windows arch:amd64 hostname:jjbuchan-envoy-]"

Win2012
"map[hostname:jjbuchan-envoy- xen-id:instance-d406d728-fc04-4f71-9a25-11b3b1d3a3fb os:windows arch:amd64]"

Ubuntu 18.04:
"map[os:linux arch:amd64 hostname:jjbuchan-envoy-ubuntu1804 xen-id:instance-d92e7ca4-d82a-4fe7-a248-bd4a22a58c46]"
```