### PR TITLE
Add bios and serial data to discovered labels

### DIFF
--- a/config/bios.go
+++ b/config/bios.go
@@ -1,0 +1,106 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package config
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// GetBiosData returns the bios vendor and version of the running system
+func GetBiosData() (map[string]string, error) {
+	biosLabels := make(map[string]string)
+	switch runtime.GOOS {
+	case "linux":
+		data, err := GetLinuxBiosData()
+		if err != nil {
+			log.WithError(err).Debug("failed to get linux bios data")
+			return nil, err
+		}
+		biosLabels = data
+	case "windows":
+		data, err := GetWindowsBiosData()
+		if err != nil {
+			log.WithError(err).Debug("failed to get windows bios data")
+			return nil, err
+		}
+		biosLabels = data
+	default:
+		return nil, errors.New("no bios data found on os with type " + runtime.GOOS)
+	}
+
+	return biosLabels, nil
+}
+
+// GetWindowsBiosData is a helper function to get the bios vendor and version for windows systems
+func GetWindowsBiosData() (map[string]string, error) {
+	var vendor, version string
+
+	output, err := exec.Command("powershell", "(Get-WmiObject win32_bios).Manufacturer").Output()
+	if err != nil {
+		log.WithError(err).Debug("failed to execute powershell command to gather bios manufacturer")
+		return nil, err
+	}
+	vendor = strings.TrimSuffix(strings.TrimSuffix(string(output), "\n"), "\r")
+	vendor = strings.ToLower(vendor)
+
+	output, err = exec.Command("powershell", "(Get-WmiObject win32_bios).SMBIOSBIOSVersion").Output()
+	if err != nil {
+		log.WithError(err).Debug("failed to execute powershell command to gather bios version")
+		return nil, err
+	}
+	version = strings.TrimSuffix(strings.TrimSuffix(string(output), "\n"), "\r")
+	version = strings.ToLower(version)
+
+	biosLabels := map[string]string{
+		"bios-vendor": vendor,
+		"bios-version": version,
+	}
+
+	return biosLabels, nil
+}
+
+// GetLinuxBiosData is a helper function to get the bios vendor and version for linux systems
+func GetLinuxBiosData() (map[string]string, error) {
+	var vendor, version string
+
+	output, err := exec.Command("dmidecode", "-s", "bios-vendor").Output()
+	if err != nil {
+		return nil, err
+	}
+	vendor = strings.TrimSuffix(string(output), "\n")
+	vendor = strings.ToLower(vendor)
+
+	output, err = exec.Command("dmidecode", "-s", "bios-version").Output()
+	if err != nil {
+		return nil, err
+	}
+	version = strings.TrimSuffix(string(output), "\n")
+	version = strings.ToLower(version)
+
+	biosLabels := map[string]string{
+		"bios-vendor": vendor,
+		"bios-version": version,
+	}
+
+	return biosLabels, nil
+}

--- a/config/bios.go
+++ b/config/bios.go
@@ -72,8 +72,8 @@ func GetWindowsBiosData() (map[string]string, error) {
 	version = strings.ToLower(version)
 
 	biosLabels := map[string]string{
-		"bios-vendor": vendor,
-		"bios-version": version,
+		BiosVendorLabel: vendor,
+		BiosVersionLabel: version,
 	}
 
 	return biosLabels, nil
@@ -98,8 +98,8 @@ func GetLinuxBiosData() (map[string]string, error) {
 	version = strings.ToLower(version)
 
 	biosLabels := map[string]string{
-		"bios-vendor": vendor,
-		"bios-version": version,
+		BiosVendorLabel: vendor,
+		BiosVersionLabel: version,
 	}
 
 	return biosLabels, nil

--- a/config/bios.go
+++ b/config/bios.go
@@ -60,7 +60,7 @@ func GetWindowsBiosData() (map[string]string, error) {
 		log.WithError(err).Debug("failed to execute powershell command to gather bios manufacturer")
 		return nil, err
 	}
-	vendor = strings.TrimSuffix(strings.TrimSuffix(string(output), "\n"), "\r")
+	vendor = strings.TrimSpace(string(output))
 	vendor = strings.ToLower(vendor)
 
 	output, err = exec.Command("powershell", "(Get-WmiObject win32_bios).SMBIOSBIOSVersion").Output()
@@ -68,7 +68,7 @@ func GetWindowsBiosData() (map[string]string, error) {
 		log.WithError(err).Debug("failed to execute powershell command to gather bios version")
 		return nil, err
 	}
-	version = strings.TrimSuffix(strings.TrimSuffix(string(output), "\n"), "\r")
+	version = strings.TrimSpace(string(output))
 	version = strings.ToLower(version)
 
 	biosLabels := map[string]string{
@@ -87,14 +87,14 @@ func GetLinuxBiosData() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	vendor = strings.TrimSuffix(string(output), "\n")
+	vendor = strings.TrimSpace(string(output))
 	vendor = strings.ToLower(vendor)
 
 	output, err = exec.Command("dmidecode", "-s", "bios-version").Output()
 	if err != nil {
 		return nil, err
 	}
-	version = strings.TrimSuffix(string(output), "\n")
+	version = strings.TrimSpace(string(output))
 	version = strings.ToLower(version)
 
 	biosLabels := map[string]string{

--- a/config/labels.go
+++ b/config/labels.go
@@ -26,6 +26,17 @@ import (
 	"runtime"
 )
 
+// Discoverable label names
+const (
+	ArchLabel        = "arch"
+	BiosVendorLabel  = "bios-vendor"
+	BiosVersionLabel = "bios-version"
+	HostnameLabel    = "hostname"
+	OsLabel          = "os"
+	SerialNoLabel    = "serial"
+	XenIdLabel       = "xen-id"
+)
+
 // ComputeLabels reads any labels specified in the config file.
 // It also auto discovers various instance identifiers such as the os type and hostname.
 // If an auto-detected label is also specified in the config file, the config file value will be used.
@@ -34,27 +45,27 @@ import (
 func ComputeLabels() (map[string]string, error) {
 	labels := make(map[string]string)
 
-	labels["os"] = runtime.GOOS
-	labels["arch"] = runtime.GOARCH
+	labels[OsLabel] = runtime.GOOS
+	labels[ArchLabel] = runtime.GOARCH
 
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to determine hostname label")
 	}
-	labels["hostname"] = hostname
+	labels[HostnameLabel] = hostname
 
 	xenId, err := GetXenId()
 	if err != nil {
 		log.WithError(err).Debug("unable to determine xen-id")
 	} else {
-		labels["xen-id"] = xenId
+		labels[XenIdLabel] = xenId
 	}
 
 	serial, err := GetSystemSerialNumber()
 	if err != nil {
 		log.WithError(err).Debug("unable to determine system serial number")
 	} else {
-		labels["serial"] = serial
+		labels[SerialNoLabel] = serial
 	}
 
 	biosData, err := GetBiosData()

--- a/config/labels.go
+++ b/config/labels.go
@@ -30,6 +30,7 @@ import (
 // It also auto discovers various instance identifiers such as the os type and hostname.
 // If an auto-detected label is also specified in the config file, the config file value will be used.
 // These labels are passed over to the server-side endpoint.
+// All label key and values are lower-case; keys can include a hyphen.
 func ComputeLabels() (map[string]string, error) {
 	labels := make(map[string]string)
 
@@ -47,6 +48,22 @@ func ComputeLabels() (map[string]string, error) {
 		log.WithError(err).Debug("unable to determine xen-id")
 	} else {
 		labels["xen-id"] = xenId
+	}
+
+	serial, err := GetSystemSerialNumber()
+	if err != nil {
+		log.WithError(err).Debug("unable to determine system serial number")
+	} else {
+		labels["serial"] = serial
+	}
+
+	biosData, err := GetBiosData()
+	if err != nil {
+		log.WithError(err).Debug("unable to determine bios data")
+	} else {
+		for k, v := range biosData {
+			labels[k] = v
+		}
 	}
 
 	configuredLabels := viper.GetStringMapString("labels")

--- a/config/serial.go
+++ b/config/serial.go
@@ -49,7 +49,7 @@ func GetSystemSerialNumber() (string, error) {
 	}
 
 	// remove new line characters
-	serial = strings.TrimSuffix(strings.TrimSuffix(serial, "\n"), "\r")
+	serial = strings.TrimSpace(serial)
 	serial = strings.ToLower(serial)
 
 	return serial, nil

--- a/config/serial.go
+++ b/config/serial.go
@@ -1,0 +1,56 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package config
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// GetSystemSerialNumber returns the serial number of the running system.
+func GetSystemSerialNumber() (string, error) {
+	var serial string
+	switch runtime.GOOS {
+	case "linux":
+		output, err := exec.Command("dmidecode", "-s", "system-serial-number").Output()
+		if err != nil {
+			log.WithError(err).Debug("failed to execute dmidecode command to gather serial number")
+			return "", err
+		}
+		serial = string(output)
+	case "windows":
+		output, err := exec.Command("powershell", "(Get-WmiObject win32_bios).SerialNumber").Output()
+		if err != nil {
+			log.WithError(err).Debug("failed to execute powershell command to gather serial number")
+			return "", err
+		}
+		serial = string(output)
+	default:
+		return "", errors.New("no serial number found on os with type " + runtime.GOOS)
+	}
+
+	// remove new line characters
+	serial = strings.TrimSuffix(strings.TrimSuffix(serial, "\n"), "\r")
+	serial = strings.ToLower(serial)
+
+	return serial, nil
+}

--- a/config/xen.go
+++ b/config/xen.go
@@ -29,7 +29,6 @@ import (
 )
 
 // GetXenId will try and detect the id of any server running on the xen hypervisor.
-// It adds this id into the list of labels with key "xen-id".
 func GetXenId() (string, error) {
 	xenId, err := GetXenIdFromCloudInit()
 	if err != nil {
@@ -55,6 +54,7 @@ func GetXenIdFromCloudInit() (string, error) {
 	}
 	// remove new line characters
 	xenId := strings.TrimSuffix(string(data), "\n")
+	xenId = strings.ToLower(xenId)
 	// the fallback datasource is iid-datasource-none when it does not exist
 	// https://cloudinit.readthedocs.io/en/latest/topics/datasources/fallback.html
 	if xenId == "iid-datasource-none" || xenId == "nocloud" {
@@ -99,6 +99,7 @@ func GetXenIdFromXenClient() (string, error) {
 
 	// remove new line characters
 	xenId = strings.TrimSuffix(strings.TrimSuffix(xenId, "\n"), "\r")
+	xenId = strings.ToLower(xenId)
 
 	return xenId, nil
 }

--- a/config/xen.go
+++ b/config/xen.go
@@ -53,7 +53,7 @@ func GetXenIdFromCloudInit() (string, error) {
 		return "", errors.Wrap(err, "failed to read from instance id path")
 	}
 	// remove new line characters
-	xenId := strings.TrimSuffix(string(data), "\n")
+	xenId := strings.TrimSpace(string(data))
 	xenId = strings.ToLower(xenId)
 	// the fallback datasource is iid-datasource-none when it does not exist
 	// https://cloudinit.readthedocs.io/en/latest/topics/datasources/fallback.html
@@ -98,7 +98,7 @@ func GetXenIdFromXenClient() (string, error) {
 	}
 
 	// remove new line characters
-	xenId = strings.TrimSuffix(strings.TrimSuffix(xenId, "\n"), "\r")
+	xenId = strings.TrimSpace(xenId)
 	xenId = strings.ToLower(xenId)
 
 	return xenId, nil


### PR DESCRIPTION
This again wasn't complicated, but more a lesson in go/powershell.

It adds bios and serial number information to the default list of labels.

```
Windows:

←[37mDEBU←[0m[0003] discovered labels                             ←[37mlabels←[0
m="map[serial:99deec4d-db66-ab77-b6e6-86d392107627 bios-vendor:xen bios-version:
4.1.5 os:windows arch:amd64 hostname:jjbuchan-envoy- xen-id:instance-d406d728-fc
04-4f71-9a25-11b3b1d3a3fb]"

Linux:

DEBU[0000] discovered labels                             labels="map[bios-vendor:Xen bios-version:4.1.5 bios-date:11/28/2013 os:linux arch:amd64 hostname:jjbuchan-envoy-ubuntu1804 xen-id:instance-d92e7ca4-d82a-4fe7-a248-bd4a22a58c46 serial:1b9a4b69-f267-9512-b9b6-118528a1b214]"
```

## To Do

* If 32bit is ever required, some additions will be needed.
* I started adding the release date field, but opted to ignore it.  That can change if needed.
* I notice the xen-id starts with `instance-`.  I wonder if we need to strip that.  I don't see anything in virgo that strips it so leaving it for now.
