### PR TITLE
Add identifier property to connection config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ configuration via a yaml file passed via `--config`. The following is an example
 file that can be used as a starting point:
 
 ```yaml
+identifier: xen-id # The corresponding label whose value acts as the identifier for the envoy. Defaults to hostname.
 labels:
   # Any key:value labels can be provided here an can override discovered labels, such as hostname
   #environment: production

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -23,4 +23,5 @@ const (
 	IngestLumberjackBind   = "ingest.lumberjack.bind"
 	IngestTelegrafJsonBind = "ingest.telegraf.json.bind"
 	AmbassadorAddress      = "ambassador.address"
+	Identifier             = "identifier"
 )

--- a/telemetry_edge/telemetry-edge.proto
+++ b/telemetry_edge/telemetry-edge.proto
@@ -16,6 +16,8 @@ message EnvoySummary {
     repeated AgentType supportedAgents = 3;
 
     map<string, string> labels = 4;
+
+    string identifier = 5;
 }
 
 enum AgentType {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-21

# What

Allows the envoy to provide a field for which it can be uniquely identified.

# How

If the envoy has a label with key matching the identifier then that value is valid.  The identifier defaults to `hostname`, which all envoys should be able to retrieve.

This value can also be overridden in the envoy config, like so

```
identifier: thisisatest
tls:
  provided:
    ca: certs/out/ca.pem
    cert: certs/out/tenantA.pem
    key: certs/out/tenantA-key.pem
ambassador:
  address: localhost:6565
lumberjack:
  bind: localhost:5044
labels:
  thisisatest: valuegoeshere
```
Note that there is a custom label with a key that matches the identifier.  As the identifier is not an auto-generated value, the envoy would throw an error if this was not specified in the config.  Any label can be used, whether it is a config provided one or auto-generated (such as os, xen-id etc.)

A debug message will be logged to show what details the envoy is providing:
```
time="2018-11-23T11:20:09-07:00" level=debug msg="Starting connection with identifier" identifierKey=thisisatest identifierValue=valuegoeshere
```

## How to test

`make test`

# Why

This will be required as part of the "node presence" / "agent health" monitoring functionality.

# TODO

The ambassador will have to handle the case of duplicate envoys trying to connect with duplicate identifier values.
