### PR TITLE
Pass envoy ID in gRPC header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: clean generate
 	go test ./...
 
 .PHONY: test-verbose
-test-verbose: generate
+test-verbose: clean generate
 	go test -v ./...
 
 test-report-junit: generate

--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -201,12 +201,12 @@ func (c *StandardEgressConnection) attach() error {
 
 	errChan := make(chan error, 10)
 
-	go c.watchForInstructions(connCtx, errChan, instructions)
-	go c.sendKeepAlives(connCtx, errChan)
+	go c.watchForInstructions(outgoingCtx, errChan, instructions)
+	go c.sendKeepAlives(outgoingCtx, errChan)
 
 	for {
 		select {
-		case <-connCtx.Done():
+		case <-outgoingCtx.Done():
 			err := instructions.CloseSend()
 			if err != nil {
 				log.WithError(err).Warn("closing send side of instructions stream")
@@ -247,7 +247,7 @@ func (c *StandardEgressConnection) PostMetric(metric *telemetry_edge.Metric) {
 	}
 }
 
-func (c *StandardEgressConnection) sendKeepAlives(connCtx context.Context, errChan chan<- error) {
+func (c *StandardEgressConnection) sendKeepAlives(ctx context.Context, errChan chan<- error) {
 	for {
 		select {
 		case <-time.After(c.KeepAliveInterval):
@@ -260,7 +260,7 @@ func (c *StandardEgressConnection) sendKeepAlives(connCtx context.Context, errCh
 			}
 			callCancel()
 
-		case <-connCtx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}

--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -158,7 +158,11 @@ func (c *StandardEgressConnection) Start(ctx context.Context, supportedAgents []
 
 func (c *StandardEgressConnection) attach() error {
 
-	log.WithField("address", c.Address).Info("dialing ambassador")
+	c.envoyId = c.idGenerator.Generate()
+	log.
+		WithField("ambassadorAddress", c.Address).
+		WithField("envoyId", c.envoyId).
+		Info("dialing ambassador")
 	// use a blocking dial, but fail on non-temp errors so that we can catch connectivity errors here rather than during
 	// the attach operation
 	conn, err := grpc.Dial(c.Address,
@@ -173,7 +177,6 @@ func (c *StandardEgressConnection) attach() error {
 	defer conn.Close()
 
 	c.client = telemetry_edge.NewTelemetryAmbassadorClient(conn)
-	c.envoyId = c.idGenerator.Generate()
 	callMetadata := metadata.Pairs(EnvoyIdHeader, c.envoyId)
 
 	cancelCtx, cancelFunc := context.WithCancel(c.ctx)

--- a/ambassador/connection_test.go
+++ b/ambassador/connection_test.go
@@ -281,7 +281,6 @@ func TestStandardEgressConnection_PostMetric(t *testing.T) {
 
 	select {
 	case postedMetric := <-ambassadorService.metrics:
-		assert.Equal(t, "id-1", postedMetric.InstanceId)
 		assert.Equal(t, "cpu", postedMetric.Metric.GetNameTagValue().Name)
 		assert.Equal(t, "id-1", ambassadorService.idViaPostMetric)
 
@@ -336,7 +335,6 @@ func TestStandardEgressConnection_PostLogEvent(t *testing.T) {
 
 	select {
 	case logEvent := <-ambassadorService.logs:
-		assert.Equal(t, "id-1", logEvent.InstanceId)
 		assert.Equal(t, telemetry_edge.AgentType_FILEBEAT, logEvent.AgentType)
 		assert.Equal(t, `{"testing":"value"}`, logEvent.JsonContent)
 		assert.Equal(t, "id-1", ambassadorService.idViaPostLogEvent)

--- a/ambassador/connection_test.go
+++ b/ambassador/connection_test.go
@@ -130,7 +130,6 @@ func TestStandardEgressConnection_Start(t *testing.T) {
 
 	select {
 	case summary := <-ambassadorService.attaches:
-		assert.Equal(t, "id-1", summary.InstanceId)
 		assert.Equal(t, "hostname", summary.Identifier)
 		assert.Equal(t, "id-1", ambassadorService.idViaAttach)
 	case <-time.After(500 * time.Millisecond):
@@ -215,7 +214,6 @@ func TestCustomIdentifierSet(t *testing.T) {
 
 	select {
 	case summary := <-ambassadorService.attaches:
-		assert.Equal(t, "id-2", summary.InstanceId)
 		assert.Equal(t, "arch", summary.Identifier)
 	case <-time.After(500 * time.Millisecond):
 		t.Error("did not see attachment in time")

--- a/ambassador/connection_test.go
+++ b/ambassador/connection_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	netContext "golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"net"
 	"strconv"
 	"testing"
@@ -37,6 +38,11 @@ import (
 )
 
 type TestingAmbassadorService struct {
+	idViaAttach       string
+	idViaKeepAlive    string
+	idViaPostMetric   string
+	idViaPostLogEvent string
+
 	done       chan struct{}
 	attaches   chan *telemetry_edge.EnvoySummary
 	keepAlives chan *telemetry_edge.KeepAliveRequest
@@ -55,22 +61,34 @@ func NewTestingAmbassadorService(done chan struct{}) *TestingAmbassadorService {
 }
 
 func (s *TestingAmbassadorService) AttachEnvoy(summary *telemetry_edge.EnvoySummary, resp telemetry_edge.TelemetryAmbassador_AttachEnvoyServer) error {
+	if md, ok := metadata.FromIncomingContext(resp.Context()); ok {
+		s.idViaAttach = md.Get(ambassador.EnvoyIdHeader)[0]
+	}
 	s.attaches <- summary
 	<-s.done
 	return nil
 }
 
 func (s *TestingAmbassadorService) KeepAlive(ctx netContext.Context, req *telemetry_edge.KeepAliveRequest) (*telemetry_edge.KeepAliveResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		s.idViaKeepAlive = md.Get(ambassador.EnvoyIdHeader)[0]
+	}
 	s.keepAlives <- req
 	return &telemetry_edge.KeepAliveResponse{}, nil
 }
 
 func (s *TestingAmbassadorService) PostLogEvent(ctx netContext.Context, log *telemetry_edge.LogEvent) (*telemetry_edge.PostLogEventResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		s.idViaPostLogEvent = md.Get(ambassador.EnvoyIdHeader)[0]
+	}
 	s.logs <- log
 	return &telemetry_edge.PostLogEventResponse{}, nil
 }
 
 func (s *TestingAmbassadorService) PostMetric(ctx netContext.Context, metric *telemetry_edge.PostedMetric) (*telemetry_edge.PostMetricResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		s.idViaPostMetric = md.Get(ambassador.EnvoyIdHeader)[0]
+	}
 	s.metrics <- metric
 	return &telemetry_edge.PostMetricResponse{}, nil
 }
@@ -114,6 +132,7 @@ func TestStandardEgressConnection_Start(t *testing.T) {
 	case summary := <-ambassadorService.attaches:
 		assert.Equal(t, "id-1", summary.InstanceId)
 		assert.Equal(t, "hostname", summary.Identifier)
+		assert.Equal(t, "id-1", ambassadorService.idViaAttach)
 	case <-time.After(500 * time.Millisecond):
 		t.Error("did not see attachment in time")
 	}
@@ -121,6 +140,7 @@ func TestStandardEgressConnection_Start(t *testing.T) {
 	select {
 	case <-ambassadorService.keepAlives:
 		// good
+		assert.Equal(t, "id-1", ambassadorService.idViaKeepAlive)
 	case <-time.After(100 * time.Millisecond):
 		t.Error("did not see keep alive in time")
 	}
@@ -217,8 +237,8 @@ func TestStandardEgressConnection_PostMetric(t *testing.T) {
 
 	done := make(chan struct{}, 1)
 	defer close(done)
-	ambassadorServer := NewTestingAmbassadorService(done)
-	telemetry_edge.RegisterTelemetryAmbassadorServer(grpcServer, ambassadorServer)
+	ambassadorService := NewTestingAmbassadorService(done)
+	telemetry_edge.RegisterTelemetryAmbassadorServer(grpcServer, ambassadorService)
 
 	go grpcServer.Serve(listener)
 	defer grpcServer.Stop()
@@ -237,7 +257,7 @@ func TestStandardEgressConnection_PostMetric(t *testing.T) {
 	defer cancel()
 
 	select {
-	case <-ambassadorServer.attaches:
+	case <-ambassadorService.attaches:
 		//continue
 	case <-time.After(500 * time.Millisecond):
 		t.Log("did not see attachment in time")
@@ -260,9 +280,66 @@ func TestStandardEgressConnection_PostMetric(t *testing.T) {
 	egressConnection.PostMetric(metric)
 
 	select {
-	case postedMetric := <-ambassadorServer.metrics:
+	case postedMetric := <-ambassadorService.metrics:
 		assert.Equal(t, "id-1", postedMetric.InstanceId)
 		assert.Equal(t, "cpu", postedMetric.Metric.GetNameTagValue().Name)
+		assert.Equal(t, "id-1", ambassadorService.idViaPostMetric)
+
+	case <-time.After(100 * time.Millisecond):
+		t.Error("did not see posted metric in time")
+	}
+}
+
+func TestStandardEgressConnection_PostLogEvent(t *testing.T) {
+	pegomock.RegisterMockTestingT(t)
+
+	ambassadorPort, err := freeport.GetFreePort()
+	require.NoError(t, err)
+
+	ambassadorAddr := net.JoinHostPort("localhost", strconv.Itoa(ambassadorPort))
+	listener, err := net.Listen("tcp", ambassadorAddr)
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	defer grpcServer.Stop()
+
+	done := make(chan struct{}, 1)
+	defer close(done)
+	ambassadorService := NewTestingAmbassadorService(done)
+	telemetry_edge.RegisterTelemetryAmbassadorServer(grpcServer, ambassadorService)
+
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	idGenerator := NewMockIdGenerator()
+	pegomock.When(idGenerator.Generate()).ThenReturn("id-1")
+
+	mockAgentsRunner := NewMockRouter()
+	viper.Set(config.AmbassadorAddress, ambassadorAddr)
+	viper.Set("tls.disabled", true)
+	egressConnection, err := ambassador.NewEgressConnection(mockAgentsRunner, idGenerator)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go egressConnection.Start(ctx, []telemetry_edge.AgentType{telemetry_edge.AgentType_FILEBEAT})
+	defer cancel()
+
+	select {
+	case <-ambassadorService.attaches:
+		//continue
+	case <-time.After(500 * time.Millisecond):
+		t.Log("did not see attachment in time")
+		t.FailNow()
+	}
+
+	egressConnection.PostLogEvent(telemetry_edge.AgentType_FILEBEAT, `{"testing":"value"}`)
+
+	select {
+	case logEvent := <-ambassadorService.logs:
+		assert.Equal(t, "id-1", logEvent.InstanceId)
+		assert.Equal(t, telemetry_edge.AgentType_FILEBEAT, logEvent.AgentType)
+		assert.Equal(t, `{"testing":"value"}`, logEvent.JsonContent)
+		assert.Equal(t, "id-1", ambassadorService.idViaPostLogEvent)
 
 	case <-time.After(100 * time.Millisecond):
 		t.Error("did not see posted metric in time")

--- a/telemetry_edge/telemetry-edge.proto
+++ b/telemetry_edge/telemetry-edge.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-option java_package = "com.rackspace.rmii.services";
+option java_package = "com.rackspace.salus.services";
 
 service TelemetryAmbassador {
     rpc AttachEnvoy (EnvoySummary) returns (stream EnvoyInstruction) {}
@@ -11,13 +11,11 @@ service TelemetryAmbassador {
 message EnvoySummary {
     string version = 1;
 
-    string instanceId = 2;
+    repeated AgentType supportedAgents = 2;
 
-    repeated AgentType supportedAgents = 3;
+    map<string, string> labels = 3;
 
-    map<string, string> labels = 4;
-
-    string identifier = 5;
+    string identifier = 4;
 }
 
 enum AgentType {
@@ -74,24 +72,22 @@ message ConfigurationOp {
 
 // mainly used to test the ambassador->envoy liveness of the channel, but could eventually
 // contain the full set of instructions of ensure consistency
-message EnvoyInstructionRefresh{}
+message EnvoyInstructionRefresh {}
 
-message KeepAliveRequest{
-    string instanceId = 1;
+message KeepAliveRequest {
 }
-message KeepAliveResponse{}
+
+message KeepAliveResponse {}
 
 message LogEvent {
-    string instanceId = 1;
-    AgentType agentType = 2;
-    string jsonContent = 3;
+    AgentType agentType = 1;
+    string jsonContent = 2;
 }
 
-message PostLogEventResponse{}
+message PostLogEventResponse {}
 
 message PostedMetric {
-    string instanceId = 1;
-    Metric metric = 2;
+    Metric metric = 1;
 }
 
 message Metric {
@@ -109,4 +105,4 @@ message NameTagValueMetric {
     map<string,string> svalues = 5;
 }
 
-message PostMetricResponse{}
+message PostMetricResponse {}


### PR DESCRIPTION
# Resolves

Discovered during review of #20 

# What

Rather than pass the envoy's instance ID in the body of each gRPC call this change prepares for the removal of that field to instead convey the ID via a gRPC (HTTP/2) header field.

# How

Uses the approach described [here](https://stackoverflow.com/a/42121891/121324) to set the metadata into the grpc outgoing context, which is then wrapped and used for the actual grpc calls. Keep in mind that "wrapped" contexts retain the values and cancellation properties of the outer context.

## How to test

`make test`

# Why

n/a

# TODO

None but there will need to be a follow PR to remove the `envoyId`/`instanceId` field from the message bodies; however, we should do that after #20 .