### PR TITLE
Enforce a timeout on connection attempt to Ambassador

### DIFF
--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package ambassador
@@ -161,7 +159,12 @@ func (c *StandardEgressConnection) attach() error {
 		Info("dialing ambassador")
 	// use a blocking dial, but fail on non-temp errors so that we can catch connectivity errors here rather than during
 	// the attach operation
-	conn, err := grpc.Dial(c.Address,
+
+	dialTimeoutCtx, dialTimeoutCancel := context.WithTimeout(c.ctx, c.GrpcCallLimit)
+	defer dialTimeoutCancel()
+
+	conn, err := grpc.DialContext(dialTimeoutCtx,
+		c.Address,
 		c.grpcTlsDialOption,
 		grpc.WithBlock(),
 		grpc.FailOnNonTempDialError(true),


### PR DESCRIPTION
# Resolves

Found during SALUS-94

# What

When the Ambassador presents a bad TLS/X509 cert, the lower level gRPC connection will quietly re-attempt the connection forever. Instead we need to wrap the connection in a timeout/deadline to ensure that connectivity issues are apparent and handled in our app layer.