### PR TITLE
Check for closed context before retrying Ambassador connections

### DIFF
--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -127,6 +127,7 @@ func (c *StandardEgressConnection) Start(ctx context.Context, supportedAgents []
 	for {
 		select {
 		case <-c.ctx.Done():
+			log.Info("Stopping egress connection handling")
 			return
 
 		default:


### PR DESCRIPTION
# What

I noticed that during some builds, [like this one](https://circleci.com/gh/racker/salus-telemetry-envoy/101), the standard egress connection would get stuck in a loop around the retry section.

# How

Add a check that the overall app context hasn't been closed before retrying the retry.

## How to test

Using existing unit tests, such as `TestStandardEgressConnection_PostLogEvent`