### PR TITLE
Namespace and enforce discovered labels

### DIFF
--- a/config/labels.go
+++ b/config/labels.go
@@ -92,7 +92,7 @@ func ComputeLabels() (map[string]string, error) {
 		if ValidateUserLabelName(k) {
 			labels[k] = v
 		} else {
-			return nil, errors.Errorf("configured label '%s' conflicts with a system namespace", k)
+			return nil, errors.Errorf("configured label '%s' conflicts with a system prefix", k)
 		}
 	}
 

--- a/config/labels.go
+++ b/config/labels.go
@@ -29,13 +29,14 @@ import (
 
 // Discoverable label names
 const (
-	// This namespace will be used to qualify labels that are discovered by the
+	// This prefix will be used to qualify labels that are discovered by the
 	// Envoy and differentiate those from the user configured labels.
-	DiscoveredNamespace = "discovered"
+	DiscoveredPrefix = "discovered"
+	PrefixDelimiter  = "."
 )
 
 var (
-	SystemNamespaces = []string{DiscoveredNamespace}
+	SystemPrefixes = []string{DiscoveredPrefix}
 
 	ArchLabel        = DiscoveredLabel("arch")
 	BiosVendorLabel  = DiscoveredLabel("bios-vendor")
@@ -102,14 +103,14 @@ func ComputeLabels() (map[string]string, error) {
 
 // DiscoveredLabel converts an unqualified label into the qualified, namespaced label name/key
 func DiscoveredLabel(label string) string {
-	return DiscoveredNamespace + "." + label
+	return DiscoveredPrefix + PrefixDelimiter + label
 }
 
 // ValidateUserLabelName will check that the given label name does not conflict with a system
-// namespace. Returns true if the user's label is valid.
+// prefix. Returns true if the user's label is valid.
 func ValidateUserLabelName(label string) bool {
-	for _, namespace := range SystemNamespaces {
-		if strings.HasPrefix(label, namespace+".") {
+	for _, prefix := range SystemPrefixes {
+		if strings.HasPrefix(label, prefix+PrefixDelimiter) {
 			return false
 		}
 	}

--- a/config/labels_test.go
+++ b/config/labels_test.go
@@ -19,6 +19,7 @@
 package config_test
 
 import (
+	"fmt"
 	"github.com/racker/telemetry-envoy/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -85,5 +86,6 @@ func TestComputeLabels_NamespaceConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = config.ComputeLabels()
-	assert.Error(t, err, "Expected error about conflicting namespace")
+	expectedErr := fmt.Sprintf("configured label '%s' conflicts with a system namespace", "discovered.hostname")
+	assert.EqualError(t, err, expectedErr, "Expected error about conflicting namespace")
 }

--- a/config/labels_test.go
+++ b/config/labels_test.go
@@ -86,6 +86,6 @@ func TestComputeLabels_NamespaceConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = config.ComputeLabels()
-	expectedErr := fmt.Sprintf("configured label '%s' conflicts with a system namespace", "discovered.hostname")
+	expectedErr := fmt.Sprintf("configured label '%s' conflicts with a system prefix", "discovered.hostname")
 	assert.EqualError(t, err, expectedErr, "Expected error about conflicting namespace")
 }

--- a/config/labels_test.go
+++ b/config/labels_test.go
@@ -36,12 +36,12 @@ func TestComputeLabels(t *testing.T) {
 		wantErr   bool
 		viperYaml string
 	}{
-		{name: "no config", wantKeys: []string{"os", "hostname", "arch"}},
-		{name: "with labels config", wantKeys: []string{"os", "hostname", "arch", "env"},
+		{name: "no config", wantKeys: []string{"discovered.os", "discovered.hostname", "discovered.arch"}},
+		{name: "with labels config", wantKeys: []string{"discovered.os", "discovered.hostname", "discovered.arch", "env"},
 			want:      map[string]string{"env": "prod"},
 			viperYaml: "labels:\n  env: prod",
 		},
-		{name: "override with config", wantKeys: []string{"os", "hostname", "arch"},
+		{name: "attempted override with config", wantKeys: []string{"discovered.os", "discovered.hostname", "hostname", "discovered.arch"},
 			want:      map[string]string{"hostname": "hostA"},
 			viperYaml: "labels:\n  hostname: hostA",
 		},
@@ -75,4 +75,15 @@ func TestComputeLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestComputeLabels_NamespaceConflict(t *testing.T) {
+	viper.Reset()
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(strings.NewReader(
+		"labels:\n  discovered.hostname: hostA"))
+	require.NoError(t, err)
+
+	_, err = config.ComputeLabels()
+	assert.Error(t, err, "Expected error about conflicting namespace")
 }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-265

# What

When we prefix the Envoy labels later in the system, we lose the ability to differentiate the labels that were configured in the Envoy's config file. Therefore we lose the ability to enforce that the user isn't attempting to overwrite a discovered label.

# How

Added some helper functions to apply the namespace as a prefix and validate the user didn't declare a label also prefixed with ours.

## How to test

Unit tests were updated and expanded.

# TODO

There will be a resource management PR to not apply the namespace there https://github.com/racker/salus-telemetry-resource-management/blob/master/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java#L259