### PR TITLE
Add init step to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ export GOPATH=$HOME/go
 export PATH="$PATH:$GOPATH/bin"
 ```
 
-### Tooling
+#### Things to Install
 
 First, install Go 1.11 (or newer). On MacOS you can install with `brew install golang`.
 
 After that you can [install the gRPC compiler tooling for Go](https://grpc.io/docs/quickstart/go.html#install-protocol-buffers-v3) 
 and [goreleaser](https://goreleaser.com/). 
-On MacOS you can install both using `make init`.
+On MacOS you can install both by performing a 
+```bash
+make init
+```
 
 ### IntelliJ Run Config
 
@@ -93,11 +96,7 @@ the scenario currently running on your system.
 
 ### Running from command-line
 
-If this is the first time building from the current directory, you must run:
-
-```bash
-make init-gotools
-```
+First, ensure you have completed the steps in the "Environment Setup" section, then...
 
 Build and install the executable by running:
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ the scenario currently running on your system.
 
 ### Running from command-line
 
+If this is the first time building from the current directory, you must run:
+
+```bash
+make init-gotools
+```
+
 Build and install the executable by running:
 
 ```bash


### PR DESCRIPTION
I had previously done this in another close, but when running as part of the bundle it failed due to pegomock.  Running this before the `make install` fixed things.
