### PR TITLE
Change labels delimiter to underscore for template friendliness

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/config/labels.go
+++ b/config/labels.go
@@ -32,7 +32,7 @@ const (
 	// This prefix will be used to qualify labels that are discovered by the
 	// Envoy and differentiate those from the user configured labels.
 	DiscoveredPrefix = "discovered"
-	PrefixDelimiter  = "."
+	PrefixDelimiter  = "_"
 )
 
 var (

--- a/config/labels_test.go
+++ b/config/labels_test.go
@@ -37,12 +37,12 @@ func TestComputeLabels(t *testing.T) {
 		wantErr   bool
 		viperYaml string
 	}{
-		{name: "no config", wantKeys: []string{"discovered.os", "discovered.hostname", "discovered.arch"}},
-		{name: "with labels config", wantKeys: []string{"discovered.os", "discovered.hostname", "discovered.arch", "env"},
+		{name: "no config", wantKeys: []string{"discovered_os", "discovered_hostname", "discovered_arch"}},
+		{name: "with labels config", wantKeys: []string{"discovered_os", "discovered_hostname", "discovered_arch", "env"},
 			want:      map[string]string{"env": "prod"},
 			viperYaml: "labels:\n  env: prod",
 		},
-		{name: "attempted override with config", wantKeys: []string{"discovered.os", "discovered.hostname", "hostname", "discovered.arch"},
+		{name: "attempted override with config", wantKeys: []string{"discovered_os", "discovered_hostname", "hostname", "discovered_arch"},
 			want:      map[string]string{"hostname": "hostA"},
 			viperYaml: "labels:\n  hostname: hostA",
 		},
@@ -82,10 +82,10 @@ func TestComputeLabels_NamespaceConflict(t *testing.T) {
 	viper.Reset()
 	viper.SetConfigType("yaml")
 	err := viper.ReadConfig(strings.NewReader(
-		"labels:\n  discovered.hostname: hostA"))
+		"labels:\n  discovered_hostname: hostA"))
 	require.NoError(t, err)
 
 	_, err = config.ComputeLabels()
-	expectedErr := fmt.Sprintf("configured label '%s' conflicts with a system prefix", "discovered.hostname")
+	expectedErr := fmt.Sprintf("configured label '%s' conflicts with a system prefix", "discovered_hostname")
 	assert.EqualError(t, err, expectedErr, "Expected error about conflicting namespace")
 }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-313

# What

While further testing templated label retrieval, it was discovered that dot-delimited labels will cause usability issues:

https://github.com/racker/salus-telemetry-monitor-management/pull/27/files#diff-2332b138120e6010ec20463e65fd4465R129

The change in this PR mirrors the change made in the model PR

https://github.com/racker/salus-telemetry-model/pull/46/files#diff-333ce0b9f272ecee04b2df955791dc32R43

## How to test

Unit test updated
