### PR TITLE
Improve agents config and add more config file docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,27 @@
 ## Run Configuration
 
 Envoy's `run` sub-command can accept some configuration via command-line arguments and/or all
-configuration via a yaml file passed via `--config`. The following is an example configuration
-file that can be used as a starting point:
+configuration via a yaml file passed via `--config`. The file **must** be named with a suffix
+of `.yaml` or `.yml`.
+
+The following is an example configuration file that can be used as a starting point:
 
 ```yaml
-resource_id: "xen-id:1234-5678-9012" # The identifier of the resource where this Envoy is running
-                                     # The convention is a name:value, but is not required.
+# The identifier of the resource where this Envoy is running
+# The convention is a type:value, but is not required.
+resource_id: "type:value"
+# Additional key:value string pairs that will be included with Envoy attachment.
 labels:
-  # Any key:value labels can be provided here an can override discovered labels, such as hostname
   #environment: production
 tls:
   auth_service:
+    # The URL of the Salus Authentication Service
     url: http://localhost:8182
+    # The provider type to use for authented allocation of client TLS certificates. Further
+    # configuration is located at tls.token_providers.<token_provider>
+    # Possible options are
+    # - keystone_v2 : uses Identity v2 for x-auth-token allocation
+    # - static : uses statically provided headers to pass to Salus Authentication Service
     token_provider: keystone_v2
   #Provides client authentication certificates pre-allocated. Remove auth_service config when using this.
   #provided:
@@ -34,15 +43,26 @@ tls:
     #  - name: Header-Name
     #    value: headerValue
 ambassador:
+  # The host:port of the secured gRPC endpoint of the Salus Ambassador
   address: localhost:6565
 ingest:
   lumberjack:
+    # host:port of where the lumberjack ingestion should bind
+    # This is intended for consuming output from filebeat
     bind: localhost:5044
   telegraf:
     json:
+      # host:port of where the telegraf json ingestion should bind
+      # This socket will accept data output by telegraf using the socket_writer plugin and
+      # a data_format of json
       bind: localhost:8094
-agent:
+agents:
+  # Data directory where Envoy stores downloaded agents and write agent configs
+  dataPath: /var/lib/telemetry-envoy
+  # The amount of time an agent is allowed to gracefully stop after a TERM signal. If the
+  # timeout is exceeded, then a KILL signal is sent.
   terminationTimeout: 5s
+  # The amount of time to pause before each restart of a failed agent process.
   restartDelay: 1s
 ```
 

--- a/agents/agents.go
+++ b/agents/agents.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"context"
 	"github.com/pkg/errors"
+	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -80,7 +81,7 @@ func IsNoAppliedConfigs(err error) bool {
 }
 
 func init() {
-	viper.SetDefault("agents.dataPath", "data-telemetry-envoy")
+	viper.SetDefault(config.AgentsDataPath, config.DefaultAgentsDataPath)
 }
 
 func downloadExtractTarGz(outputPath, url string, exePath string) error {

--- a/agents/agents_router.go
+++ b/agents/agents_router.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package agents
@@ -21,6 +19,7 @@ package agents
 import (
 	"context"
 	"github.com/pkg/errors"
+	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -37,7 +36,7 @@ type StandardAgentsRouter struct {
 
 func NewAgentsRunner() (Router, error) {
 	ar := &StandardAgentsRouter{
-		DataPath: viper.GetString("agents.dataPath"),
+		DataPath: viper.GetString(config.AgentsDataPath),
 	}
 
 	commandHandler := NewCommandHandler()

--- a/agents/agents_router_test.go
+++ b/agents/agents_router_test.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package agents_test
@@ -22,6 +20,7 @@ import (
 	"github.com/petergtz/pegomock"
 	"github.com/racker/telemetry-envoy/agents"
 	"github.com/racker/telemetry-envoy/agents/matchers"
+	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,7 @@ func TestAgentsRunner_ProcessInstall(t *testing.T) {
 			dataPath, err := ioutil.TempDir("", "test_agents")
 			require.NoError(t, err)
 			defer os.RemoveAll(dataPath)
-			viper.Set("agents.dataPath", dataPath)
+			viper.Set(config.AgentsDataPath, dataPath)
 
 			agentsRunner, err := agents.NewAgentsRunner()
 			require.NoError(t, err)

--- a/agents/command_handler.go
+++ b/agents/command_handler.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package agents
@@ -22,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"github.com/pkg/errors"
+	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -49,14 +48,9 @@ type CommandHandler interface {
 
 type StandardCommandHandler struct{}
 
-const (
-	agentTerminationTimeoutConfig = "agent.terminationTimeout"
-	agentRestartDelayConfig       = "agent.restartDelay"
-)
-
 func init() {
-	viper.SetDefault(agentTerminationTimeoutConfig, 5*time.Second)
-	viper.SetDefault(agentRestartDelayConfig, 1*time.Second)
+	viper.SetDefault(config.AgentsTerminationTimeoutConfig, 5*time.Second)
+	viper.SetDefault(config.AgentsRestartDelayConfig, 1*time.Second)
 }
 
 func NewCommandHandler() CommandHandler {
@@ -131,7 +125,7 @@ func (h *StandardCommandHandler) WaitOnAgentCommand(ctx context.Context, agentRu
 		log.
 			WithField("agentType", runningContext.agentType).
 			Info("scheduling agent restart")
-		time.AfterFunc(viper.GetDuration(agentRestartDelayConfig), func() {
+		time.AfterFunc(viper.GetDuration(config.AgentsRestartDelayConfig), func() {
 			agentRunner.EnsureRunningState(ctx, false)
 		})
 	}
@@ -221,7 +215,7 @@ func (*StandardCommandHandler) Stop(runningContext *AgentRunningContext) {
 		}
 
 		select {
-		case <-time.After(viper.GetDuration(agentTerminationTimeoutConfig)):
+		case <-time.After(viper.GetDuration(config.AgentsTerminationTimeoutConfig)):
 			log.WithField("agentType", runningContext.agentType).Warn("agent process did not stop in time using TERM, now using KILL")
 			err = runningContext.cmd.Process.Signal(syscall.SIGKILL)
 			if err != nil {

--- a/agents/hooks_for_test.go
+++ b/agents/hooks_for_test.go
@@ -1,24 +1,23 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package agents
 
 import (
+	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	"github.com/spf13/viper"
 	"os"
@@ -39,7 +38,7 @@ func UnregisterAllAgentRunners() {
 }
 
 func SetAgentRestartDelay(delay time.Duration) {
-	viper.Set(agentRestartDelayConfig, delay)
+	viper.Set(config.AgentsRestartDelayConfig, delay)
 }
 
 func RunAgentRunningContext(ctx *AgentRunningContext) error {
@@ -48,7 +47,7 @@ func RunAgentRunningContext(ctx *AgentRunningContext) error {
 }
 
 func SetAgentTerminationTimeout(delay time.Duration) {
-	viper.Set(agentTerminationTimeoutConfig, delay)
+	viper.Set(config.AgentsTerminationTimeoutConfig, delay)
 }
 
 func WaitOnAgentRunningContextStopped(t *testing.T, ctx *AgentRunningContext, timeout time.Duration) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package cmd
@@ -99,4 +97,8 @@ func init() {
 
 	runCmd.Flags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, runCmd.Flag("resource-id"))
+
+	runCmd.Flags().String("data-path", config.DefaultAgentsDataPath,
+		"Data directory where Envoy stores downloaded agents and write agent configs")
+	viper.BindPFlag(config.AgentsDataPath, runCmd.Flag("data-path"))
 }

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -1,28 +1,31 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package config
 
 // Viper configuration keys used inter-package
 const (
-	IngestLumberjackBind   = "ingest.lumberjack.bind"
-	IngestTelegrafJsonBind = "ingest.telegraf.json.bind"
-	AmbassadorAddress      = "ambassador.address"
-	ResourceId             = "resource_id"
-	Zone                   = "zone"
+	AgentsDataPath                 = "agents.dataPath"
+	AgentsTerminationTimeoutConfig = "agents.terminationTimeout"
+	AgentsRestartDelayConfig       = "agents.restartDelay"
+	IngestLumberjackBind           = "ingest.lumberjack.bind"
+	IngestTelegrafJsonBind         = "ingest.telegraf.json.bind"
+	AmbassadorAddress              = "ambassador.address"
+	ResourceId                     = "resource_id"
+	Zone                           = "zone"
+
+	DefaultAgentsDataPath = "/var/lib/telemetry-envoy"
 )


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-439

# What

Our config file docs were lacking some important information, there was inconsistency in `agents` and `agent` sections of the yaml, and there wasn't a command-line arg for the Envoy data path.

# How

Declare some more shared constants for the agents config keys and change and fix the other things mentioned above.

## How to test

Existing unit tests

# TODO

- [x] update envoy config files provided in https://github.com/racker/salus-telemetry-bundle/tree/master/dev since the default data path is now situated under `/var`