### PR TITLE
Use underscore delimiter in discovered labels

### DIFF
--- a/config/labels.go
+++ b/config/labels.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package config
@@ -39,12 +37,12 @@ var (
 	SystemPrefixes = []string{DiscoveredPrefix}
 
 	ArchLabel        = DiscoveredLabel("arch")
-	BiosVendorLabel  = DiscoveredLabel("bios-vendor")
-	BiosVersionLabel = DiscoveredLabel("bios-version")
+	BiosVendorLabel  = DiscoveredLabel("bios_vendor")
+	BiosVersionLabel = DiscoveredLabel("bios_version")
 	HostnameLabel    = DiscoveredLabel("hostname")
 	OsLabel          = DiscoveredLabel("os")
 	SerialNoLabel    = DiscoveredLabel("serial")
-	XenIdLabel       = DiscoveredLabel("xen-id")
+	XenIdLabel       = DiscoveredLabel("xen_id")
 )
 
 // ComputeLabels reads any labels specified in the config file.


### PR DESCRIPTION
# What

The validation constraint on resource labels requires that label keys contain only underscores, letters, and digits. This adjusts the discovered labels to match that rule.

## How to test

Existing unit tests