### PR TITLE
Tell logrus to log to stdout instead of default stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package cmd
@@ -59,6 +57,10 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+
+	// log to stdout since most service wrappers and container orchestration expects that
+	log.SetOutput(os.Stdout)
+
 	// Configure logging thresholds
 	if debug {
 		log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-448

# What

logrus logs to stderr by default and since we're not seeing any output when running envoy as a runit service, I'm suspecting it's because it only mentions redirecting stdout of the `run` managed service

http://manpages.ubuntu.com/manpages/bionic/en/man8/runsv.8.html

## How to test

Manually verify logs as before, but to stdout.