### PR TITLE
Handle SIGTERM and explicitly set telegraf flush interval

### DIFF
--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -40,6 +40,8 @@ const (
 var telegrafMainConfigTmpl = template.Must(template.New("telegrafMain").Parse(`
 [agent]
   interval = "10s"
+  flush_interval = "10s"
+  flush_jitter = "2s"
   omit_hostname = true
 [[outputs.socket_writer]]
   address = "tcp://{{.IngestHost}}:{{.IngestPort}}"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 var runCmd = &cobra.Command{
@@ -78,6 +79,8 @@ func handleInterrupts(body func(ctx context.Context)) {
 			log.Info("cancelling application context")
 			cancel()
 		case <-rootCtx.Done():
+			// allow for agent processes to be notified
+			time.Sleep(1 * time.Second)
 			os.Exit(0)
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 var runCmd = &cobra.Command{
@@ -65,7 +66,7 @@ var runCmd = &cobra.Command{
 
 func handleInterrupts(body func(ctx context.Context)) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
+	signal.Notify(signalChan, os.Interrupt, os.Kill, syscall.SIGTERM)
 
 	rootCtx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-463

# What

`runit`'s stop/restart commands send a SIGTERM to the process, but Envoy was only intercepting SIGINT.

Also explicitly setting the flush interval just to be sure. It looks like it defaults to `interval`'s value, but didn't find documentation to confirm that.

## How to test

Manually for signal handling.