### PR TITLE
Extracted agent exe file wasn't being closed before starting it

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ nfpm:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "SNAPSHOT-{{.Commit}}"
+  name_template: "SNAPSHOT-{{.ShortCommit}}"
 changelog:
   sort: asc
   filters:

--- a/agents/agents.go
+++ b/agents/agents.go
@@ -121,6 +121,7 @@ func downloadExtractTarGz(outputPath, url string, exePath string) error {
 				log.WithError(err).Error("unable to open file for writing")
 				continue
 			}
+			defer file.Close()
 
 			_, err = io.Copy(file, tarReader)
 			if err != nil {

--- a/agents/command_handler.go
+++ b/agents/command_handler.go
@@ -77,7 +77,7 @@ func (h *StandardCommandHandler) StartAgentCommand(runningContext *AgentRunningC
 
 	waitForChan, err := h.setupCommandLogging(cmdCtx, agentType, cmd, waitFor)
 	if err != nil {
-		return errors.New("logging and watching command output")
+		return errors.Wrap(err, "failed to setup command logging")
 	}
 
 	runningContext.stopping = false


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-462

# What

https://github.com/racker/salus-telemetry-envoy/pull/43 was necessary, but not completely the right fix for the issue:

```
time="2019-06-26T20:36:08Z" level=warning msg="failed to start agent" agentType=TELEGRAF error="failed to start command: fork/exec CURRENT/bin/telegraf: text file busy"
```

Developing/testing on MacOS was masking the real issue where the extracted executable file wasn't being closed and Linux it didn't want to exec a file that is open for writing in another process.

Also made the goreleaser snapshot naming a little shorter, such as

```
      • creating                  archive=dist/telemetry-envoy_SNAPSHOT-160f34d_Linux_x86_64.tar.gz
```

FYI, using `make snapshot` is handy for creating a cross-compile on Mac OS that can run on Linux.