### PR TITLE
Stop agents and purge config on detach

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,12 +38,14 @@ var runCmd = &cobra.Command{
 
 		handleInterrupts(func(ctx context.Context) {
 
-			agentsRunner, err := agents.NewAgentsRunner()
+			detachChan := make(chan struct{}, 1)
+
+			agentsRunner, err := agents.NewAgentsRunner(detachChan)
 			if err != nil {
 				log.WithError(err).Fatal("unable to setup agent runner")
 			}
 
-			connection, err := ambassador.NewEgressConnection(agentsRunner, ambassador.NewIdGenerator())
+			connection, err := ambassador.NewEgressConnection(agentsRunner, detachChan, ambassador.NewIdGenerator())
 			if err != nil {
 				log.WithError(err).Fatal("unable to setup ambassador connection")
 			}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-470

# What

At this point in the Envoy connection handling https://github.com/racker/salus-telemetry-envoy/blob/93da632d9f87850e60dcc31db6ffa68be23b09be/ambassador/connection.go#L135 I realized that it wasn't actually stopping agents or purging monitor configs. Starting with an empty state was always an assumption of each envoy connection/instance ID...but the connection loss wasn't actually fulfilling that assumption.

Before the fix, the following metrics ingestion errors show the telegraf agent was still running after connection loss to the Ambassador:

```
time="2019-07-02T07:58:13-05:00" level=warning msg=terminating error="failed to receive instruction: rpc error: code = Unavailable desc = transport is closing"
time="2019-07-02T07:58:13-05:00" level=warning msg="delaying until next attempt" delay=275.470765ms error=closed
time="2019-07-02T07:58:13-05:00" level=info msg="dialing ambassador" ambassadorAddress="localhost:6565" envoyId=0d3b0d86-9cc9-11e9-8f92-c4b301c45f69
time="2019-07-02T07:58:14-05:00" level=debug msg="unmarshaled metric line" m="{1562072294000 internal_write map[output:socket_writer] map[buffer_limit:10000 buffer_size:4 metrics_added:4 metrics_dropped:0 metrics_filtered:0 metrics_written:0 write_time_ns:0]}"
time="2019-07-02T07:58:14-05:00" level=debug msg="processing metric" m="&{1562072294000 internal_write map[output:socket_writer] map[buffer_limit:10000 buffer_size:4 metrics_added:4 metrics_dropped:0 metrics_filtered:0 metrics_written:0 write_time_ns:0]}"
time="2019-07-02T07:58:14-05:00" level=debug msg="posting metric" metric="nameTagValue:<name:\"internal_write\" timestamp:1562072294000 tags:<key:\"output\" value:\"socket_writer\" > fvalues:<key:\"buffer_limit\" value:10000 > fvalues:<key:\"buffer_size\" value:4 > fvalues:<key:\"metrics_added\" value:4 > fvalues:<key:\"metrics_dropped\" value:0 > fvalues:<key:\"metrics_filtered\" value:0 > fvalues:<key:\"metrics_written\" value:0 > fvalues:<key:\"write_time_ns\" value:0 > > "
time="2019-07-02T07:58:14-05:00" level=warning msg="failed to post metric" error="rpc error: code = Canceled desc = context canceled"
```

# How

This change introduces a "detach channel" between the egress/ambassador connection handling and the agents runner/route. When connection loss is detected a "signal" is sent over the newly introduced channel, the agents runner picks up on the signal, and in turn stops any running agents and purges configs.

The following shows Envoy logs after the fix was implemented:

```
time="2019-07-02T08:46:25-05:00" level=warning msg="terminating connection due to error" error="failed to receive instruction: rpc error: code = Unavailable desc = transport is closing"
time="2019-07-02T08:46:25-05:00" level=debug msg="closing attach receiver stream"
time="2019-07-02T08:46:25-05:00" level=warning msg="delaying until next attempt" delay=428.980033ms error=closed
time="2019-07-02T08:46:25-05:00" level=debug msg="stopping agent runners"
time="2019-07-02T08:46:25-05:00" level=debug msg="stopping agent" agentType=TELEGRAF
time="2019-07-02T08:46:25-05:00" level=info msg="2019-07-02T13:46:25Z I! [agent] Hang on, flushing any cached metrics before shutdown\n" agentType=TELEGRAF
time="2019-07-02T08:46:25-05:00" level=debug msg="stopping command stdout forwarding to logs" agentType=TELEGRAF
time="2019-07-02T08:46:25-05:00" level=info msg="agent exited successfully" agentType=TELEGRAF
time="2019-07-02T08:46:25-05:00" level=debug msg="purging config" agentType=FILEBEAT
time="2019-07-02T08:46:25-05:00" level=debug msg="purging config" agentType=TELEGRAF
time="2019-07-02T08:46:26-05:00" level=info msg="dialing ambassador" ambassadorAddress="localhost:6565" envoyId=c95e225e-9ccf-11e9-be91-c4b301c45f69
```

## How to test

Unit tests updated