### PR TITLE
replace envoy config files with a config webserver

### DIFF
--- a/agents/command_handler.go
+++ b/agents/command_handler.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -258,3 +259,9 @@ func (c *AgentRunningContext) Pid() int {
 		return -1
 	}
 }
+
+// envStrings are strings in the format "foo=bar"
+func (c *AgentRunningContext) AppendEnv(envStrings... string) {
+	c.cmd.Env = append(os.Environ(), envStrings...)
+}
+

--- a/agents/hooks_for_test.go
+++ b/agents/hooks_for_test.go
@@ -78,20 +78,32 @@ func CreatePreRunningAgentRunningContext() *AgentRunningContext {
 	}
 }
 
-func (tr *TelegrafRunner) GetCurrentConfigWithToken(token string) ([]byte, error) {
+func (tr *TelegrafRunner) getCurrentConfigWithToken(token string) (*http.Response, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", tr.configServerURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("authorization", "Token "+ token)
-	resp, err := client.Do(req)
+	return client.Do(req)
+
+}
+
+// Always uses the correct token
+func(tr *TelegrafRunner) GetCurrentConfig() ([]byte, error) {
+	resp, err := tr.getCurrentConfigWithToken(tr.configServerToken)
 	if err != nil {
 		return nil, err
 	}
 	return ioutil.ReadAll(resp.Body)
 }
 
-func(tr *TelegrafRunner) GetCurrentConfig() ([]byte, error) {
-	return tr.GetCurrentConfigWithToken(tr.configServerToken)
+// Always uses a bad token
+func(tr *TelegrafRunner) GetCurrentConfigWithBadToken() ([]byte, int,  error) {
+	resp, err := tr.getCurrentConfigWithToken(tr.configServerToken + "BadToken")
+	if err != nil {
+		return nil, 0,  err
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+	return content, resp.StatusCode, err
 }

--- a/agents/hooks_for_test.go
+++ b/agents/hooks_for_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	"github.com/spf13/viper"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -78,10 +78,20 @@ func CreatePreRunningAgentRunningContext() *AgentRunningContext {
 	}
 }
 
-func (tr *TelegrafRunner) GetCurrentConfig() io.Reader {
+func (tr *TelegrafRunner) GetCurrentConfigWithToken(token string) ([]byte, error) {
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", tr.configServerURL, nil)
-	req.Header.Add("authorization", "Token " + tr.configServerToken)
-	resp, _ := client.Do(req)
-	return resp.Body
+	req, err := http.NewRequest("GET", tr.configServerURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("authorization", "Token "+ token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(resp.Body)
+}
+
+func(tr *TelegrafRunner) GetCurrentConfig() ([]byte, error) {
+	return tr.GetCurrentConfigWithToken(tr.configServerToken)
 }

--- a/agents/hooks_for_test.go
+++ b/agents/hooks_for_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/racker/telemetry-envoy/config"
 	"github.com/racker/telemetry-envoy/telemetry_edge"
 	"github.com/spf13/viper"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"testing"
@@ -74,4 +76,12 @@ func CreatePreRunningAgentRunningContext() *AgentRunningContext {
 			Process: &os.Process{},
 		},
 	}
+}
+
+func (tr *TelegrafRunner) GetCurrentConfig() io.Reader {
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", tr.configServerURL, nil)
+	req.Header.Add("authorization", "Token " + tr.configServerToken)
+	resp, _ := client.Do(req)
+	return resp.Body
 }

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -107,6 +107,7 @@ func (tr *TelegrafRunner) Load(agentBasePath string) error {
 	tr.configServerMux = http.NewServeMux()
 	tr.configServerMux.Handle("/" + serverId, tr.configServerHandler)
 
+	// Get the next available port
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return errors.Wrap(err, "couldn't create http listener")
@@ -169,7 +170,6 @@ func (tr *TelegrafRunner) concatConfigs() []byte {
 func (tr *TelegrafRunner) handleTelegrafConfigurationOp(op *telemetry_edge.ConfigurationOp) bool {
 	switch op.GetType() {
 	case telemetry_edge.ConfigurationOp_CREATE, telemetry_edge.ConfigurationOp_MODIFY:
-
 		var finalConfig []byte
 		var err error
 		finalConfig, err = ConvertJsonToTelegrafToml(op.GetContent(), op.ExtraLabels)
@@ -178,7 +178,6 @@ func (tr *TelegrafRunner) handleTelegrafConfigurationOp(op *telemetry_edge.Confi
 			return false
 			}
 		tr.tomlConfigs[op.GetId()] = finalConfig
-
 		return true
 
 		case telemetry_edge.ConfigurationOp_REMOVE:
@@ -187,9 +186,7 @@ func (tr *TelegrafRunner) handleTelegrafConfigurationOp(op *telemetry_edge.Confi
 				return true
 			}
 			return false
-
 			}
-
 	return false
 }
 

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -129,6 +129,7 @@ func (tr *TelegrafRunner) Load(agentBasePath string) error {
 }
 
 func (tr *TelegrafRunner) serve(listener net.Listener) {
+	log.Info("started webServer")
 	err := http.Serve(listener, tr.configServerMux)
 	// Note this is probably not the best way to handle webserver failure
 	log.Fatalf("web server error %v", err)

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -157,7 +157,13 @@ func (tr *TelegrafRunner) ProcessConfig(configure *telemetry_edge.EnvoyInstructi
 func (tr *TelegrafRunner) concatConfigs() []byte {
 	var configs []byte
 	configs = append(configs, tr.tomlMainConfig...)
+	// telegraf can only handle one 'inputs' header per file so add exactly one here
+	configs = append(configs, []byte("[inputs]")...)
 	for _, v := range tr.tomlConfigs {
+		// remove the other redundant '[inputs]' headers here
+		if bytes.Equal([]byte("[inputs]"),v[0:8]) {
+			v = v[8:]
+		}
 		configs = append(configs, v...)
 	}
 	return configs

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -124,8 +124,6 @@ func (tr *TelegrafRunner) Load(agentBasePath string) error {
 
 	go tr.serve(listener)
 
-	log.Infof("GBJ curl -v -H 'authorization: Token %s' %s", tr.configServerToken, tr.configServerURL)
-
 	return nil
 }
 

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -123,7 +123,10 @@ func (tr *TelegrafRunner) Load(agentBasePath string) error {
 	tr.configServerToken = uuid.NewV4()
 	tr.configServerURL = fmt.Sprintf("http://localhost:%d/%s", tr.configServerPort, tr.configServerId.String())
 	tr.tomlConfigs = make(map[string][]byte)
-	tr.tomlMainConfig = nil
+	mainConfig, err := tr.createMainConfig()
+
+	tr.tomlMainConfig = mainConfig
+	tr.tomlWebPage = mainConfig
 
 	go http.Serve(listener, nil)
 

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -122,14 +122,14 @@ func (tr *TelegrafRunner) Load(agentBasePath string) error {
 	tr.tomlWebPage = mainConfig
 
 
-	go tr.Serve(listener)
+	go tr.serve(listener)
 
 	log.Infof("GBJ curl -v -H 'authorization: Token %s' %s", tr.configServerToken, tr.configServerURL)
 
 	return nil
 }
 
-func (tr *TelegrafRunner) Serve(listener net.Listener) {
+func (tr *TelegrafRunner) serve(listener net.Listener) {
 	err := http.Serve(listener, tr.configServerMux)
 	// Note this is probably not the best way to handle webserver failure
 	log.Fatalf("web server error %v", err)

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -180,13 +180,13 @@ func (tr *TelegrafRunner) handleTelegrafConfigurationOp(op *telemetry_edge.Confi
 		tr.tomlConfigs[op.GetId()] = finalConfig
 		return true
 
-		case telemetry_edge.ConfigurationOp_REMOVE:
-			if _, ok := tr.tomlConfigs[op.GetId()]; ok {
-				delete(tr.tomlConfigs, op.GetId())
-				return true
-			}
-			return false
-			}
+	case telemetry_edge.ConfigurationOp_REMOVE:
+		if _, ok := tr.tomlConfigs[op.GetId()]; ok {
+			delete(tr.tomlConfigs, op.GetId())
+			return true
+		}
+		return false
+		}
 	return false
 }
 

--- a/agents/telegraf_test.go
+++ b/agents/telegraf_test.go
@@ -70,11 +70,11 @@ func TestTelegrafRunner_ProcessConfig_CreateModify(t *testing.T) {
 			err = runner.ProcessConfig(configure)
 			require.NoError(t, err)
 
-			content := make([]byte, 2000)
-			runner.GetCurrentConfig().Read(content)
+			content, err := runner.GetCurrentConfig()
+			require.NoError(t, err)
+
 			assert.Contains(t, string(content), "outputs.socket_writer")
 			assert.Contains(t, string(content), "address = \"tcp://localhost:8094\"")
-
 			assert.Contains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
 		})
 	}
@@ -145,9 +145,10 @@ func TestTelegrafRunner_EnsureRunningState_FullSequence(t *testing.T) {
 	}
 	err = telegrafRunner.ProcessConfig(createConfig)
 	require.NoError(t, err)
-	configs, err := ioutil.ReadDir(path.Join(dataPath, "config.d"))
+	content, err := telegrafRunner.GetCurrentConfig()
 	require.NoError(t, err)
-	assert.Len(t, configs, 1)
+	assert.Contains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
+
 
 	runningContext := agents.CreatePreRunningAgentRunningContext()
 
@@ -187,9 +188,10 @@ func TestTelegrafRunner_EnsureRunningState_FullSequence(t *testing.T) {
 	}
 	err = telegrafRunner.ProcessConfig(modifyConfig)
 	require.NoError(t, err)
-	configs, err = ioutil.ReadDir(path.Join(dataPath, "config.d"))
+	content, err = telegrafRunner.GetCurrentConfig()
 	require.NoError(t, err)
-	assert.Len(t, configs, 1)
+	assert.Contains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
+
 
 	telegrafRunner.EnsureRunningState(ctx, true)
 
@@ -206,9 +208,9 @@ func TestTelegrafRunner_EnsureRunningState_FullSequence(t *testing.T) {
 	}
 	err = telegrafRunner.ProcessConfig(removeConfig)
 	require.NoError(t, err)
-	configs, err = ioutil.ReadDir(path.Join(dataPath, "config.d"))
+	content, err = telegrafRunner.GetCurrentConfig()
 	require.NoError(t, err)
-	assert.Len(t, configs, 0)
+	assert.NotContains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
 
 	telegrafRunner.EnsureRunningState(ctx, true)
 

--- a/agents/telegraf_test.go
+++ b/agents/telegraf_test.go
@@ -157,7 +157,6 @@ func TestTelegrafRunner_EnsureRunningState_FullSequence(t *testing.T) {
 		matchers.AnyTelemetryEdgeAgentType(),
 		pegomock.AnyString(),
 		pegomock.AnyString(),
-		pegomock.AnyString(), pegomock.AnyString(),
 		pegomock.AnyString(), pegomock.AnyString())).
 		ThenReturn(runningContext)
 
@@ -168,7 +167,6 @@ func TestTelegrafRunner_EnsureRunningState_FullSequence(t *testing.T) {
 			matchers.EqTelemetryEdgeAgentType(telemetry_edge.AgentType_TELEGRAF),
 			pegomock.EqString("CURRENT/bin/telegraf"),
 			pegomock.EqString(dataPath),
-			pegomock.AnyString(), pegomock.AnyString(),
 			pegomock.AnyString(), pegomock.AnyString())
 
 	commandHandler.VerifyWasCalled(pegomock.Never()).


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-435

# What

Improve envoy security by using config webserver instead of local config files

## How to test

run the unit tests

# Note
Note that this is only tested on telegraf 1.11, (not all the earlier versions of telegraf support web based config.)
