### PR TITLE
Don't debug log agent's command environment variables

### DIFF
--- a/agents/command_handler.go
+++ b/agents/command_handler.go
@@ -86,7 +86,7 @@ func (h *StandardCommandHandler) StartAgentCommand(runningContext *AgentRunningC
 
 	log.
 		WithField("agentType", agentType).
-		WithField("cmd", cmd).
+		WithField("args", cmd.Args).
 		Debug("starting agent")
 	err = cmd.Start()
 	if err != nil {
@@ -261,7 +261,6 @@ func (c *AgentRunningContext) Pid() int {
 }
 
 // envStrings are strings in the format "foo=bar"
-func (c *AgentRunningContext) AppendEnv(envStrings... string) {
+func (c *AgentRunningContext) AppendEnv(envStrings ...string) {
 	c.cmd.Env = append(os.Environ(), envStrings...)
 }
-


### PR DESCRIPTION
# What

I noticed the envoy debug logs the entire command object used to kick off an agent like telegraf:

```
time="2019-07-10T12:58:46-05:00" level=debug msg="starting agent" agentType=TELEGRAF cmd="&{CURRENT/bin/telegraf [CURRENT/bin/telegraf --config http://localhost:50487/91849e8c-65cf-4b23-836f-434a907ce0f8] [PATH=/Users/geof0549/.sdkman/candidates/scala/current/bin:
```

but we should really not log the environment variables since the envoy now conveys the `INFLUX_TOKEN` there and the user might have other sensitive environment variables.

# How

Just log the command line args.