### PR TITLE
Create zip archive releases for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,9 @@ archive:
     windows: Windows
     386: i386
     amd64: x86_64
+  format_overrides:
+    - goos: windows
+      format: zip
 nfpm:
   name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
   replacements:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,31 +14,33 @@ builds:
   ignore:
   - goos: darwin
     goarch: 386
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  format_overrides:
-    - goos: windows
-      format: zip
-nfpm:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  vendor: Rackspace
-  homepage: https://www.rackspace.com/
-  description: Monitoring application which submits system metrics for further analysis.
-  license: Apache 2.0
-  formats:
-    - deb
-    - rpm
+archives:
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+nfpms:
+  -
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    vendor: Rackspace
+    homepage: https://www.rackspace.com/
+    description: Monitoring application which submits system metrics for further analysis.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-466

# What

On Windows it's awkward to use tar.gz archives, but GoReleaser makes it easy to fix that.

# How

Use override option described in https://goreleaser.com/customization/#Archive

Also fixing some deprecation warnings while I was in there:
```
      • ARCHIVES
            • DEPRECATED: `archive` should not be used anymore, check https://goreleaser.com/deprecations#archive for more info.
      • LINUX PACKAGES WITH NFPM
            • DEPRECATED: `nfpm` should not be used anymore, check https://goreleaser.com/deprecations#nfpm for more info.
```

## How to test

```
make snapshot
```

and confirm zip archive for Windows:
```
ls dist/*.zip
```