### PR TITLE
Stop agent runner during agent install/upgrade

### DIFF
--- a/agents/agents_router.go
+++ b/agents/agents_router.go
@@ -131,6 +131,8 @@ func (ar *StandardAgentsRouter) ProcessInstall(install *telemetry_edge.EnvoyInst
 			return
 		}
 
+		specificAgentRunners[agentType].Stop()
+
 		// NOTE rather than symlink, might later use a metadata file
 		currentSymlinkPath := path.Join(agentBasePath, currentVerLink)
 		err = os.Remove(currentSymlinkPath)
@@ -158,6 +160,9 @@ func (ar *StandardAgentsRouter) ProcessInstall(install *telemetry_edge.EnvoyInst
 			return
 		}
 
+		// There's a chance a new agent version might get started here with "old" incompatible
+		// configs, but the Ambassador will follow up with a re-evaluation of bound monitors
+		// and will send newly translated config to eventually resolve this.
 		specificAgentRunners[agentType].EnsureRunningState(ar.ctx, false)
 
 		log.WithFields(log.Fields{

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -224,7 +224,7 @@ func (tr *TelegrafRunner) EnsureRunningState(ctx context.Context, applyConfigs b
 		if applyConfigs {
 			log.
 				WithField("agentType", telemetry_edge.AgentType_TELEGRAF).
-				Debug("signaling config reload")
+				Info("signaling config reload")
 			tr.handleConfigReload()
 		}
 		return

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -218,8 +218,15 @@ func (tr *TelegrafRunner) EnsureRunningState(ctx context.Context, applyConfigs b
 	}
 
 	if tr.running.IsRunning() {
-		log.Debug("telegraf is already running, signaling config reload")
-		tr.handleConfigReload()
+		log.
+			WithField("agentType", telemetry_edge.AgentType_TELEGRAF).
+			Debug("already running")
+		if applyConfigs {
+			log.
+				WithField("agentType", telemetry_edge.AgentType_TELEGRAF).
+				Debug("signaling config reload")
+			tr.handleConfigReload()
+		}
 		return
 	}
 

--- a/telemetry_edge/telemetry-edge.pb.go
+++ b/telemetry_edge/telemetry-edge.pb.go
@@ -8,6 +8,8 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -1358,6 +1360,26 @@ type TelemetryAmbassadorServer interface {
 	PostLogEvent(context.Context, *LogEvent) (*PostLogEventResponse, error)
 	PostMetric(context.Context, *PostedMetric) (*PostMetricResponse, error)
 	PostTestMonitorResults(context.Context, *TestMonitorResults) (*PostTestMonitorResultsResponse, error)
+}
+
+// UnimplementedTelemetryAmbassadorServer can be embedded to have forward compatible implementations.
+type UnimplementedTelemetryAmbassadorServer struct {
+}
+
+func (*UnimplementedTelemetryAmbassadorServer) AttachEnvoy(req *EnvoySummary, srv TelemetryAmbassador_AttachEnvoyServer) error {
+	return status.Errorf(codes.Unimplemented, "method AttachEnvoy not implemented")
+}
+func (*UnimplementedTelemetryAmbassadorServer) KeepAlive(ctx context.Context, req *KeepAliveRequest) (*KeepAliveResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method KeepAlive not implemented")
+}
+func (*UnimplementedTelemetryAmbassadorServer) PostLogEvent(ctx context.Context, req *LogEvent) (*PostLogEventResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PostLogEvent not implemented")
+}
+func (*UnimplementedTelemetryAmbassadorServer) PostMetric(ctx context.Context, req *PostedMetric) (*PostMetricResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PostMetric not implemented")
+}
+func (*UnimplementedTelemetryAmbassadorServer) PostTestMonitorResults(ctx context.Context, req *TestMonitorResults) (*PostTestMonitorResultsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PostTestMonitorResults not implemented")
 }
 
 func RegisterTelemetryAmbassadorServer(s *grpc.Server, srv TelemetryAmbassadorServer) {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-481

# What

While verifying the Envoy aspect of monitor translation I noticed that during an agent upgrade, the old agent process wasn't being stopped.

# How

Ensure the agent runner is stopped during any installation, especially an upgrade.

There were a couple of other tweaks while I was in here.

## How to test

Existing unit tests

# Related PRs

- https://github.com/racker/salus-telemetry-monitor-management/pull/90
- https://github.com/racker/salus-telemetry-ambassador/pull/63
