### PR TITLE
Detect systemd before performing service install and systemctl calls

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ nfpms:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "SNAPSHOT-{{.ShortCommit}}"
+  name_template: "{{.Tag}}-SNAPSHOT-{{.ShortCommit}}"
 changelog:
   sort: asc
   filters:

--- a/pkg/scripts/postinstall.sh
+++ b/pkg/scripts/postinstall.sh
@@ -7,6 +7,31 @@ DATA_DIR=/var/lib/telemetry-envoy
 ETC_DIR=/etc/salus
 SERVICE=telemetry-envoy
 
+function uses_systemd {
+  [[ "$(readlink /proc/1/exe)" == */systemd ]]
+}
+
+function post_install_systemd {
+  if [ -d /lib/systemd ]; then
+    # Debian/Ubuntu
+    SYSTEMD_PATH=/lib/systemd
+  elif [ -d /usr/lib/systemd ]; then
+    # Redhat
+    SYSTEMD_PATH=/usr/lib/systemd
+  else
+    echo "ERROR: unable to detect SYSTEMD_PATH"
+    exit 1
+  fi
+
+  cp -f ${SCRIPT_DIR}/${SERVICE}.service ${SYSTEMD_PATH}/system/
+
+  # load/reload service unit
+  systemctl daemon-reload
+
+  # for upgrades, restart service...only if already active
+  systemctl try-restart ${SERVICE}
+}
+
 setcap CAP_SETFCAP+p /usr/local/bin/telemetry-envoy
 
 # Only adjust top level of data directory since just need to fix up initial, empty dir.
@@ -18,21 +43,7 @@ chown -R ${USER}:${GROUP} ${ETC_DIR}
 # ...and only telemetry-envoy can access config, since there are sensitive fields
 chmod -R go-rwx ${ETC_DIR}
 
-if [ -d /lib/systemd ]; then
-  # Debian/Ubuntu
-  SYSTEMD_PATH=/lib/systemd
-elif [ -d /usr/lib/systemd ]; then
-  # Redhat
-  SYSTEMD_PATH=/usr/lib/systemd
-else
-  echo "ERROR: unable to detect SYSTEMD_PATH"
-  exit 1
+if uses_systemd; then
+  post_install_systemd
 fi
-
-cp -f ${SCRIPT_DIR}/${SERVICE}.service ${SYSTEMD_PATH}/system/
-
-# load/reload service unit
-systemctl daemon-reload
-
-# for upgrades, restart service...only if already active
-systemctl try-restart ${SERVICE}
+# else manual service setup is needed...for now

--- a/pkg/scripts/postremove.sh
+++ b/pkg/scripts/postremove.sh
@@ -4,26 +4,37 @@ SERVICE=telemetry-envoy
 ETC_DIR=/etc/salus
 DATA_DIR=/var/lib/telemetry-envoy
 
-if [ -d /lib/systemd ]; then
-  # Debian/Ubuntu
-  SYSTEMD_PATH=/lib/systemd
-elif [ -d /usr/lib/systemd ]; then
-  # Redhat
-  SYSTEMD_PATH=/usr/lib/systemd
-else
-  echo "ERROR: unable to detect SYSTEMD_PATH"
-  exit 1
+function uses_systemd {
+  [[ "$(readlink /proc/1/exe)" == */systemd ]]
+}
+
+function post_remove_systemd {
+  if [ -d /lib/systemd ]; then
+    # Debian/Ubuntu
+    SYSTEMD_PATH=/lib/systemd
+  elif [ -d /usr/lib/systemd ]; then
+    # Redhat
+    SYSTEMD_PATH=/usr/lib/systemd
+  else
+    echo "ERROR: unable to detect SYSTEMD_PATH"
+    exit 1
+  fi
+
+  # debs pass upgrade, remove, or purge
+  # rpms pass number of versions installed, so 0 means none remain
+  if [ "$1" == "remove" ] || [ "$1" == "purge" ] || [ "$1" == "0" ]; then
+    systemctl disable ${SERVICE}
+
+    rm -f ${SYSTEMD_PATH}/system/${SERVICE}.service
+
+    systemctl daemon-reload
+  fi
+}
+
+if uses_systemd; then
+  post_remove_systemd "$1"
 fi
-
-# debs pass upgrade, remove, or purge
-# rpms pass number of versions installed, so 0 means none remain
-if [ "$1" == "remove" ] || [ "$1" == "purge" ] || [ "$1" == "0" ]; then
-  systemctl disable ${SERVICE}
-
-  rm -f ${SYSTEMD_PATH}/system/${SERVICE}.service
-
-  systemctl daemon-reload
-fi
+# else manual service removal is needed
 
 if [ "$1" == "purge" ]; then
   rm -rf ${ETC_DIR}

--- a/pkg/scripts/preremove.sh
+++ b/pkg/scripts/preremove.sh
@@ -2,12 +2,22 @@
 
 SERVICE=telemetry-envoy
 
+function uses_systemd {
+  [[ "$(readlink /proc/1/exe)" == */systemd ]]
+}
+
+function pre_remove_systemd {
+    systemctl stop ${SERVICE}.service
+}
 
 # debs pass upgrade, remove, or purge
 # rpms pass number of versions installed, so 0 means none remain
 if [ "$1" == "remove" ] || [ "$1" == "purge" ] || [ "$1" == "0" ]; then
 
-  systemctl stop ${SERVICE}.service
+  if uses_systemd; then
+    pre_remove_systemd
+  fi
+  # else manual service stopping is needed
 
 fi
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-639

# What

On Ubuntu 14.04 (and other non-systemd distro/releases), the `systemctl` command is not present and systemd service files should not even be installed.

# How

Use [the same trick telegraf package scripts used](https://github.com/influxdata/telegraf/blob/d71c8ed3b984394990e19a21c55495f5a6c308a0/scripts/post-install.sh#L71) to detect if systemd is the init process (pid==1).

For now, non-systemd systems will not have any service files installed or started. In a later enhancement we could add support for upstart and/or System V style init.

# How to test

Manually with two separate vagrant boxes, `ubuntu/trusty64` and `ubuntu/xenial64`, to confirm the behaviors on non-systemd and systemd enabled systems.
