### PR TITLE
perf test ingestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ starts the envoy in perf test mode at port 8100
 
 The rate of metrics generated can be changed with a rest call like so:
 ```bash
-curl -X POST  "http://localhost:8100/?metricsPerMinute=15&floatsPerMetric=20"
+curl http://localhost:8100/ -d metricsPerMinute=15 -d floatsPerMetric=20
 ```
 ### Locally testing gRPC/proto changes
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ An example invocation of this sub-command is:
 
 With this sub-command, logs are output to stderr so that file descriptor redirects can be used to separate the envoy logging from the posted telemetry content.
 
+### Running perf test mode
+```bash
+telemetry-envoy run --perf-test-port=8100 --config=envoy-config-provided.yml
+```
+starts the envoy in perf test mode at port 8100
+
+The rate of metrics generated can be changed with a rest call like so:
+```bash
+curl  "http://localhost:8100/?metricsPerMinute=15&floatsPerMetric=20"
+```
 ### Locally testing gRPC/proto changes
 
 If making local changes to the gRPC/proto files in `salus-telemetry-protocol`, you'll need to make a temporary change to `go.mod` to reference those. Add the following after the `require` block:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ starts the envoy in perf test mode at port 8100
 
 The rate of metrics generated can be changed with a rest call like so:
 ```bash
-curl  "http://localhost:8100/?metricsPerMinute=15&floatsPerMetric=20"
+curl -X POST  "http://localhost:8100/?metricsPerMinute=15&floatsPerMetric=20"
 ```
 ### Locally testing gRPC/proto changes
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
       - |
         set -ex
         make init
-        make test-report-junit
+        make test
         cat test-results/report.xml
 
   - id: UPLOAD_RESULTS

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,8 +9,3 @@ steps:
         set -ex
         make init
         make test
-
-  - id: UPLOAD_RESULTS
-    name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', 'test-results/report.xml', "gs://salus-cache/salus-telemetry-envoy-test-results/report-${BUILD_ID}.xml"]
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,6 @@ steps:
         set -ex
         make init
         make test
-        cat test-results/report.xml
 
   - id: UPLOAD_RESULTS
     name: 'gcr.io/cloud-builders/gsutil'

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.telemetry-envoy.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output")
 
-	rootCmd.PersistentFlags().Int("perf-test-port", 0, "Enable perf test mode port")
+	rootCmd.PersistentFlags().Int("perf-test-port", 0, "Enable perf test mode/port")
 	viper.BindPFlag(config.PerfTestPort, rootCmd.PersistentFlags().Lookup("perf-test-port"))
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,8 +54,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.telemetry-envoy.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output")
 
-	rootCmd.PersistentFlags().Bool("perf-test-mode", false, "Enable perf test mode")
-	viper.BindPFlag(config.PerfTestMode, rootCmd.PersistentFlags().Lookup("perf-test-mode"))
+	rootCmd.PersistentFlags().Int("perf-test-port", 0, "Enable perf test mode port")
+	viper.BindPFlag(config.PerfTestPort, rootCmd.PersistentFlags().Lookup("perf-test-port"))
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.telemetry-envoy.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output")
 
+	rootCmd.PersistentFlags().Bool("perf-test-mode", false, "Enable perf test mode")
+	viper.BindPFlag(config.PerfTestMode, rootCmd.PersistentFlags().Lookup("perf-test-mode"))
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))
 

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -31,7 +31,7 @@ const (
 	AmbassadorAddress               = "ambassador.address"
 	ResourceId                      = "resource_id"
 	Zone                            = "zone"
-	PerfTestMode                    = "perf_test_mode"
+	PerfTestPort                    = "perf_test_port"
 
 	DefaultAgentsDataPath                  = "/var/lib/telemetry-envoy"
 	DefaultAgentsTestMonitorTimeout        = 30 * time.Second

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -31,6 +31,7 @@ const (
 	AmbassadorAddress               = "ambassador.address"
 	ResourceId                      = "resource_id"
 	Zone                            = "zone"
+	PerfTestMode                    = "perf_test_mode"
 
 	DefaultAgentsDataPath                  = "/var/lib/telemetry-envoy"
 	DefaultAgentsTestMonitorTimeout        = 30 * time.Second

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ingest
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"github.com/pkg/errors"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
+	"github.com/racker/telemetry-envoy/ambassador"
+	"github.com/racker/telemetry-envoy/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"net"
+)
+
+const (
+	telegrafJsonMetricChanSize = 10
+)
+
+type TelegrafJson struct {
+	listener   net.Listener
+	metrics    chan *telegrafJsonMetric
+	egressConn ambassador.EgressConnection
+}
+
+type telegrafJsonMetric struct {
+	Timestamp int64
+	Name      string
+	Tags      map[string]string
+	Fields    map[string]interface{}
+}
+
+func init() {
+	viper.SetDefault(config.IngestTelegrafJsonBind, "localhost:8094")
+
+	registerIngestor(&TelegrafJson{})
+}
+
+func (t *TelegrafJson) Bind(conn ambassador.EgressConnection) error {
+	bind := viper.GetString(config.IngestTelegrafJsonBind)
+
+	listener, err := net.Listen("tcp", bind)
+	if err != nil {
+		return errors.Wrap(err, "failed to bind telegraf json listenener")
+	}
+
+	t.listener = listener
+	t.egressConn = conn
+
+	return nil
+}
+
+func (t *TelegrafJson) Start(ctx context.Context) {
+
+	t.metrics = make(chan *telegrafJsonMetric, telegrafJsonMetricChanSize)
+	go t.acceptConnections(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.listener.Close()
+			return
+
+		case m := <-t.metrics:
+			t.processMetric(m)
+		}
+	}
+}
+
+func (t *TelegrafJson) acceptConnections(ctx context.Context) {
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			// errors during accept usually just mean the listener is closed
+			log.WithError(err).Debug("error while accepting telegraf ingest egressConn")
+			return
+		} else {
+			go t.handleConnection(ctx, conn)
+		}
+	}
+}
+
+func (t *TelegrafJson) handleConnection(ctx context.Context, conn net.Conn) {
+	log.WithField("addr", conn.RemoteAddr()).Info("handling telegraf json connection")
+
+	defer conn.Close()
+
+	scanner := bufio.NewScanner(conn)
+
+	for scanner.Scan() {
+		var m telegrafJsonMetric
+
+		content := scanner.Bytes()
+		if len(content) > 0 {
+			err := json.Unmarshal(content, &m)
+			if err != nil {
+				log.WithError(err).WithField("content", string(content)).Warn("failed to decode telegraf json metric")
+			} else {
+				log.WithField("m", &m).Debug("successfully unmarshaled json metric")
+				t.metrics <- &m
+			}
+		}
+	}
+
+	if scanner.Err() != nil {
+		log.WithError(scanner.Err()).Warn("failure while reading json lines")
+	}
+}
+
+func (t *TelegrafJson) processMetric(m *telegrafJsonMetric) {
+	log.WithField("m", m).Debug("processing metric")
+	fvalues := make(map[string]float64)
+	svalues := make(map[string]string)
+
+	for name, value := range m.Fields {
+		switch v := value.(type) {
+		case float64:
+			fvalues[name] = v
+		case string:
+			svalues[name] = v
+		}
+	}
+
+	outMetric := &telemetry_edge.Metric{
+		Variant: &telemetry_edge.Metric_NameTagValue{
+			NameTagValue: &telemetry_edge.NameTagValueMetric{
+				Name:      m.Name,
+				Timestamp: m.Timestamp,
+				Tags:      m.Tags,
+				Fvalues:   fvalues,
+				Svalues:   svalues,
+			},
+		},
+	}
+
+	t.egressConn.PostMetric(outMetric)
+}

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -59,9 +59,9 @@ func (p *PerfTestIngestor) Start(ctx context.Context) {
 		return
 	}
 
+	p.ticker = time.NewTicker(time.Duration(int64(time.Minute) / int64(p.metricsPerMinute)))
 	go p.startPerfTestServer()
 	for {
-		p.ticker = time.NewTicker(time.Duration(int64(time.Minute) / int64(p.metricsPerMinute)))
 		select {
 		case <-ctx.Done():
 			p.ticker.Stop()

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -31,11 +31,11 @@ import (
 )
 
 type PerfTestIngestor struct {
-	egressConn               ambassador.EgressConnection
-	metricsPerMinute         int64
-	floatsPerMetric          int64
-	ticker                   *time.Ticker
-	newRateC                 chan int64
+	egressConn       ambassador.EgressConnection
+	metricsPerMinute int64
+	floatsPerMetric  int64
+	ticker           *time.Ticker
+	newRateC         chan int64
 }
 
 func init() {
@@ -46,7 +46,7 @@ func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return nil
 	}
-	log.Info("gbj3 entering perfTest mode")
+	log.Info("entering perfTest mode")
 	p.egressConn = conn
 	p.metricsPerMinute = 60
 	p.floatsPerMetric = 10

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -34,8 +34,7 @@ type PerfTestIngestor struct {
 	egressConn               ambassador.EgressConnection
 	currentMetricsPerMinute  int64
 	previousMetricsPerMinute int64
-	currentFloatsPerMetric   int64
-	previousFloatsPerMetric  int64
+	floatsPerMetric          int64
 	serverHandler            http.HandlerFunc
 	ticker                   *time.Ticker
 }
@@ -52,8 +51,7 @@ func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
 	p.egressConn = conn
 	p.previousMetricsPerMinute = 0
 	p.currentMetricsPerMinute = 60
-	p.previousFloatsPerMetric = 0
-	p.currentFloatsPerMetric = 10
+	p.floatsPerMetric = 10
 	p.serverHandler = p.handler
 	return nil
 }
@@ -121,7 +119,7 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("floatsPerMetric parameter must be an int: " + err.Error()))
 			return
 		}
-		p.currentFloatsPerMetric = int64(floatsCount)
+		p.floatsPerMetric = int64(floatsCount)
 		floatsPerMetricSet = true
 	}
 	if metricsPerMinuteSet == false && floatsPerMetricSet == false {
@@ -129,7 +127,7 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d",
-		p.currentMetricsPerMinute, p.currentFloatsPerMetric)))
+		p.currentMetricsPerMinute, p.floatsPerMetric)))
 	return
 }
 
@@ -139,7 +137,7 @@ func (p *PerfTestIngestor) processMetric() {
 	tags := make(map[string]string)
 	tags["test_tag"] = "perfTestTag"
 	svalues["result_type"] = "success"
-	for i := 0; int64(i) < p.currentFloatsPerMetric; i++ {
+	for i := 0; int64(i) < p.floatsPerMetric; i++ {
 		fvalues[fmt.Sprintf("result_code%d", i)] = -2.0
 	}
 	outMetric := &telemetry_edge.Metric{

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -17,137 +17,57 @@
 package ingest
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
-	"github.com/pkg/errors"
 	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/telemetry-envoy/ambassador"
-	"github.com/racker/telemetry-envoy/config"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"net"
+	"time"
 )
 
-const (
-	telegrafJsonMetricChanSize = 10
-)
-
-type TelegrafJson struct {
-	listener   net.Listener
-	metrics    chan *telegrafJsonMetric
+type PerfTestIngestor struct {
 	egressConn ambassador.EgressConnection
 }
 
-type telegrafJsonMetric struct {
-	Timestamp int64
-	Name      string
-	Tags      map[string]string
-	Fields    map[string]interface{}
-}
-
 func init() {
-	viper.SetDefault(config.IngestTelegrafJsonBind, "localhost:8094")
-
-	registerIngestor(&TelegrafJson{})
+	registerIngestor(&PerfTestIngestor{})
 }
 
-func (t *TelegrafJson) Bind(conn ambassador.EgressConnection) error {
-	bind := viper.GetString(config.IngestTelegrafJsonBind)
-
-	listener, err := net.Listen("tcp", bind)
-	if err != nil {
-		return errors.Wrap(err, "failed to bind telegraf json listenener")
-	}
-
-	t.listener = listener
-	t.egressConn = conn
-
+func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
+	p.egressConn = conn
 	return nil
 }
 
-func (t *TelegrafJson) Start(ctx context.Context) {
-
-	t.metrics = make(chan *telegrafJsonMetric, telegrafJsonMetricChanSize)
-	go t.acceptConnections(ctx)
-
+func (p *PerfTestIngestor) Start(ctx context.Context) {
+	ticker := time.NewTicker(15 * time.Second)
 	for {
 		select {
 		case <-ctx.Done():
-			t.listener.Close()
+			ticker.Stop()
 			return
 
-		case m := <-t.metrics:
-			t.processMetric(m)
+		case <-ticker.C:
+			p.processMetric()
 		}
 	}
 }
 
-func (t *TelegrafJson) acceptConnections(ctx context.Context) {
-	for {
-		conn, err := t.listener.Accept()
-		if err != nil {
-			// errors during accept usually just mean the listener is closed
-			log.WithError(err).Debug("error while accepting telegraf ingest egressConn")
-			return
-		} else {
-			go t.handleConnection(ctx, conn)
-		}
-	}
-}
-
-func (t *TelegrafJson) handleConnection(ctx context.Context, conn net.Conn) {
-	log.WithField("addr", conn.RemoteAddr()).Info("handling telegraf json connection")
-
-	defer conn.Close()
-
-	scanner := bufio.NewScanner(conn)
-
-	for scanner.Scan() {
-		var m telegrafJsonMetric
-
-		content := scanner.Bytes()
-		if len(content) > 0 {
-			err := json.Unmarshal(content, &m)
-			if err != nil {
-				log.WithError(err).WithField("content", string(content)).Warn("failed to decode telegraf json metric")
-			} else {
-				log.WithField("m", &m).Debug("successfully unmarshaled json metric")
-				t.metrics <- &m
-			}
-		}
-	}
-
-	if scanner.Err() != nil {
-		log.WithError(scanner.Err()).Warn("failure while reading json lines")
-	}
-}
-
-func (t *TelegrafJson) processMetric(m *telegrafJsonMetric) {
-	log.WithField("m", m).Debug("processing metric")
+func (p *PerfTestIngestor) processMetric() {
 	fvalues := make(map[string]float64)
 	svalues := make(map[string]string)
-
-	for name, value := range m.Fields {
-		switch v := value.(type) {
-		case float64:
-			fvalues[name] = v
-		case string:
-			svalues[name] = v
-		}
-	}
-
+	tags := make(map[string]string)
+	tags["test_tag"] = "perfTestTag"
+	svalues["result_type"] = "success"
+	fvalues["result_code"] = -2.0
 	outMetric := &telemetry_edge.Metric{
 		Variant: &telemetry_edge.Metric_NameTagValue{
 			NameTagValue: &telemetry_edge.NameTagValueMetric{
-				Name:      m.Name,
-				Timestamp: m.Timestamp,
-				Tags:      m.Tags,
+				Name:      "perfTestMetric",
+				Timestamp: time.Now().Unix(),
+				Tags:      tags,
 				Fvalues:   fvalues,
 				Svalues:   svalues,
 			},
 		},
 	}
 
-	t.egressConn.PostMetric(outMetric)
+	p.egressConn.PostMetric(outMetric)
 }

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -49,7 +49,7 @@ func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
 	log.Info("entering perfTest mode")
 	p.egressConn = conn
 	p.previousMetricsPerMinute = 0;
-	p.currentMetricsPerMinute = 12;
+	p.currentMetricsPerMinute = 60;
 	p.serverHandler = p.handler
 	return nil
 }
@@ -107,7 +107,7 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.currentMetricsPerMinute = int64(count)
-	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d", count)))
+	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d", p.currentMetricsPerMinute)))
         return
 }
 

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -18,24 +18,24 @@ package ingest
 
 import (
 	"context"
+	"fmt"
 	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/telemetry-envoy/ambassador"
-	"time"
 	"github.com/racker/telemetry-envoy/config"
-	"github.com/spf13/viper"
-	"net/http"
-	"net"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"net"
+	"net/http"
 	"strconv"
-	"fmt"
+	"time"
 )
 
 type PerfTestIngestor struct {
-	egressConn ambassador.EgressConnection
-	currentMetricsPerMinute int64 
+	egressConn               ambassador.EgressConnection
+	currentMetricsPerMinute  int64
 	previousMetricsPerMinute int64
-	serverHandler http.HandlerFunc
-	ticker *time.Ticker
+	serverHandler            http.HandlerFunc
+	ticker                   *time.Ticker
 }
 
 func init() {
@@ -48,8 +48,8 @@ func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
 	}
 	log.Info("entering perfTest mode")
 	p.egressConn = conn
-	p.previousMetricsPerMinute = 0;
-	p.currentMetricsPerMinute = 60;
+	p.previousMetricsPerMinute = 0
+	p.currentMetricsPerMinute = 60
 	p.serverHandler = p.handler
 	return nil
 }
@@ -58,15 +58,15 @@ func (p *PerfTestIngestor) Start(ctx context.Context) {
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return
 	}
-	
+
 	go p.startPerfTestServer()
 	for {
-		if (p.previousMetricsPerMinute != p.currentMetricsPerMinute) {
-			if (p.ticker != nil) {
+		if p.previousMetricsPerMinute != p.currentMetricsPerMinute {
+			if p.ticker != nil {
 				p.ticker.Stop()
 			}
 			p.previousMetricsPerMinute = p.currentMetricsPerMinute
-			p.ticker = time.NewTicker(time.Duration(int64(time.Minute)/p.currentMetricsPerMinute))
+			p.ticker = time.NewTicker(time.Duration(int64(time.Minute) / p.currentMetricsPerMinute))
 		}
 		select {
 		case <-ctx.Done():
@@ -92,6 +92,7 @@ func (p *PerfTestIngestor) startPerfTestServer() {
 	// Note this is probably not the best way to handle webserver failure
 	log.Fatalf("perf test server error %v", err)
 }
+
 func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 	params := r.URL.Query()
 	metricsPerMinuteVals, ok := params["metricsPerMinute"]
@@ -108,7 +109,7 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 	}
 	p.currentMetricsPerMinute = int64(count)
 	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d", p.currentMetricsPerMinute)))
-        return
+	return
 }
 
 func (p *PerfTestIngestor) processMetric() {

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -128,7 +128,8 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("metricsPerMinute or floatsPerMetric parameter required"))
 		return
 	}
-	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d", p.currentMetricsPerMinute, p.currentFloatsPerMetric)))
+	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d",
+		p.currentMetricsPerMinute, p.currentFloatsPerMetric)))
 	return
 }
 

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	log "github.com/sirupsen/logrus"
 	"strconv"
+	"fmt"
 )
 
 type PerfTestIngestor struct {
@@ -97,6 +98,7 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 	}
 	p.metricCount = int64(count)
 	p.ticker = time.NewTicker(time.Duration(p.metricCount * int64(time.Second)))
+	_, _ = w.Write([]byte(fmt.Sprintf("metricCount set to %d", count)))
         return
 }
 

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -32,6 +32,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+	"net/url"
+	"strconv"
 )
 
 func TestPerfTestIngestor(t *testing.T) {
@@ -62,7 +64,7 @@ func TestPerfTestIngestor(t *testing.T) {
 	assert.Equal(t, "perfTestTag",
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Tags["test_tag"])
 	assert.Equal(t, float64(0),
-		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["result_code0"])
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["duration_0"])
 	assert.Equal(t, 10,
 		len(args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues))
 	assert.Equal(t, "success",
@@ -70,7 +72,9 @@ func TestPerfTestIngestor(t *testing.T) {
 
 	metricsPerMinute := 10
 	floatsPerMetric := 20
-	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d&floatsPerMetric=%d", port, metricsPerMinute, floatsPerMetric), "", nil)
+	resp, err := http.PostForm(fmt.Sprintf("http://localhost:%d", port),
+		url.Values{"metricsPerMinute": {strconv.Itoa(metricsPerMinute)},
+			"floatsPerMetric": {strconv.Itoa(floatsPerMetric)}})
 	require.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	body, err := ioutil.ReadAll(resp.Body)

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -62,15 +62,18 @@ func TestPerfTestIngestor(t *testing.T) {
 	assert.Equal(t, "perfTestTag",
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Tags["test_tag"])
 	assert.Equal(t, float64(-2.0),
-		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["result_code"])
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["result_code0"])
+	assert.Equal(t, 10,
+		len(args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues))
 	assert.Equal(t, "success",
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Svalues["result_type"])
 
 	metricsPerMinute := 10
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d", port, metricsPerMinute))
+	floatsPerMetric := 20
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d&floatsPerMetric=%d", port, metricsPerMinute, floatsPerMetric))
 	require.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("metricsPerMinute set to %d", metricsPerMinute), string(body))
+	assert.Equal(t, fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d", metricsPerMinute, floatsPerMetric), string(body))
 }

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ingest_test
+
+import (
+	"context"
+	"github.com/petergtz/pegomock"
+	"github.com/phayes/freeport"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
+	"github.com/racker/telemetry-envoy/config"
+	"github.com/racker/telemetry-envoy/ingest"
+	"github.com/racker/telemetry-envoy/ingest/matchers"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+	"net/http"
+	"fmt"
+	"io/ioutil"
+)
+
+func TestPerfTestIngestor(t *testing.T) {
+	pegomock.RegisterMockTestingT(t)
+	mockEgressConnection := NewMockEgressConnection()
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	viper.Set(config.PerfTestPort, port)
+	ingestor := &ingest.PerfTestIngestor{}
+	err = ingestor.Bind(mockEgressConnection)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go ingestor.Start(ctx)
+	defer cancel()
+
+	// allow for ingestor to bind and webserver to start
+	time.Sleep(5 * time.Millisecond)
+
+	args := mockEgressConnection.VerifyWasCalledEventually(
+		pegomock.Times(2),
+		4*time.Second,
+	).PostMetric(matchers.AnyPtrToTelemetryEdgeMetric()).GetAllCapturedArguments()
+
+	require.Len(t, args, 2)
+	assert.Equal(t, "perfTestMetric",
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Name)
+	assert.Equal(t, "perfTestTag",
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Tags["test_tag"])
+	assert.Equal(t, float64(-2.0),
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["result_code"])
+	assert.Equal(t, "success",
+		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Svalues["result_type"])
+
+
+        metricsPerMinute := 10
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d", port, metricsPerMinute))
+	require.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("metricsPerMinute set to %d", metricsPerMinute), string(body))
+}

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -61,7 +61,7 @@ func TestPerfTestIngestor(t *testing.T) {
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Name)
 	assert.Equal(t, "perfTestTag",
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Tags["test_tag"])
-	assert.Equal(t, float64(-2.0),
+	assert.Equal(t, float64(0),
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues["result_code0"])
 	assert.Equal(t, 10,
 		len(args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Fvalues))
@@ -70,7 +70,7 @@ func TestPerfTestIngestor(t *testing.T) {
 
 	metricsPerMinute := 10
 	floatsPerMetric := 20
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d&floatsPerMetric=%d", port, metricsPerMinute, floatsPerMetric))
+	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d&floatsPerMetric=%d", port, metricsPerMinute, floatsPerMetric), "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	body, err := ioutil.ReadAll(resp.Body)

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -18,6 +18,7 @@ package ingest_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/petergtz/pegomock"
 	"github.com/phayes/freeport"
 	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
@@ -27,11 +28,10 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
-	"net/http"
-	"fmt"
-	"io/ioutil"
 )
 
 func TestPerfTestIngestor(t *testing.T) {
@@ -66,8 +66,7 @@ func TestPerfTestIngestor(t *testing.T) {
 	assert.Equal(t, "success",
 		args[0].Variant.(*telemetry_edge.Metric_NameTagValue).NameTagValue.Svalues["result_type"])
 
-
-        metricsPerMinute := 10
+	metricsPerMinute := 10
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/?metricsPerMinute=%d", port, metricsPerMinute))
 	require.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -30,10 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
-	"testing"
-	"time"
 	"net/url"
 	"strconv"
+	"testing"
+	"time"
 )
 
 func TestPerfTestIngestor(t *testing.T) {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-675

# What

Creates a perf test mode which allows the envoy to generate dummy metrics for performance testing.  Also includes a webserver that accepts rest calls to change the rate of metrics per minute and the size/(number of float values) in each metric sent.

# How

A new "--perf-test-port=<port number>" command line option invokes perf test mode and starts the webserver on <port number> parameter.

That webserver creates a rest endpoint which allows the rate/size of the metrics to be changed.

The metrics generation is implemented with a standalone "ingestor", i.e. one that doesn't ingest but just generates metrics on its own with connecting to an external agent.

## How to test

unit tests added
