### PR TITLE
Improved the logging of failed auth service request

### DIFF
--- a/auth/auth_service.go
+++ b/auth/auth_service.go
@@ -1,29 +1,29 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package auth
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -72,7 +72,9 @@ func (p *AuthServiceCertProvider) ProvideCertificates(config *TlsConfig) (*tls.C
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode != 200 {
-		return nil, nil, errors.Errorf("http request to auth service failed: %s", httpResp.Status)
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, httpResp.Body)
+		return nil, nil, errors.Errorf("http request to auth service failed: %s: %s", httpResp.Status, buf.String())
 	}
 
 	var resp authServiceResponse


### PR DESCRIPTION
# What

When repose (in front of auth-service) fails or auth-service itself gives a non-200 response, there are no further details logged in the Envoy about why it failed. For example:

```
time="2020-01-09T18:31:28Z" level=fatal msg="unable to setup ambassador connection" error="http request to auth service failed: 500 Internal Server Error"
```

# How

Grab the response body and include that in the error that gets logged.

## How to test

I temporarily changed my auth-service code to throw an IllegalArgumentException to confirm that the gory details got logged when pointing my envoy at my local auth-service.