### PR TITLE
Adds a test for Apache monitor conversion

### DIFF
--- a/agents/converters_test.go
+++ b/agents/converters_test.go
@@ -35,6 +35,7 @@ func TestConvertJsonToToml(t *testing.T) {
 		extraLabels map[string]string
 		interval    int64
 	}{
+		{name: "apache"},
 		{name: "cpu"},
 		{name: "disk"},
 		{name: "diskio"},

--- a/agents/testdata/TestConvertJsonToToml_apache.json
+++ b/agents/testdata/TestConvertJsonToToml_apache.json
@@ -1,0 +1,11 @@
+{
+  "type": "apache",
+  "url": "rackspace.com",
+  "username": "user",
+  "password": "pass",
+  "timeout": null,
+  "tlsCa": null,
+  "tlsCert": null,
+  "tlsKey": null,
+  "insecureSkipVerify": null
+}

--- a/agents/testdata/TestConvertJsonToToml_apache.toml
+++ b/agents/testdata/TestConvertJsonToToml_apache.toml
@@ -1,0 +1,6 @@
+[inputs]
+
+  [[inputs.apache]]
+    password = "pass"
+    url = "rackspace.com"
+    username = "user"


### PR DESCRIPTION
# What

Adds a test for apache monitor conversion from json to toml.
# Why

This shows that the `null` fields in the config will be ignored when converting to toml.
