### PR TITLE
Allowed ingestors to be disabled and improved resolving of listener address of those

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ On MacOS you can install both by performing a
 make init
 ```
 
+#### (Re-)Generating Mock Files
+
+Generated mock files are used for unit testing. If using `make test` the generation of those mock files happens automatically; however, if you need to specifically (re)generate those, you can use `make generate`.
+
 ### IntelliJ Run Config
 
 This module is actually a submodule of the [salus-telemetry-bundle] (https://github.com/racker/salus-telemetry-bundle).  The following instructions expect that you have installed that repo with this as a submodule.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ingest:
     # This is intended for consuming output from filebeat
     # This ingestor can be disabled by setting this to an empty value, but will render the filebeat
     # agent unusable.
+    # The port can be set to 0 or left off to allow any available port to be used.
     bind: localhost:5044
   telegraf:
     json:
@@ -59,6 +60,7 @@ ingest:
       # a data_format of json
       # This ingestor can be disabled by setting this to an empty value, but will render the telegraf
       # and other agents unusable.
+      # The port can be set to 0 or left off to allow any available port to be used.
       bind: localhost:8094
 agents:
   # Data directory where Envoy stores downloaded agents and write agent configs

--- a/README.md
+++ b/README.md
@@ -49,12 +49,16 @@ ingest:
   lumberjack:
     # host:port of where the lumberjack ingestion should bind
     # This is intended for consuming output from filebeat
+    # This ingestor can be disabled by setting this to an empty value, but will render the filebeat
+    # agent unusable.
     bind: localhost:5044
   telegraf:
     json:
       # host:port of where the telegraf json ingestion should bind
       # This socket will accept data output by telegraf using the socket_writer plugin and
       # a data_format of json
+      # This ingestor can be disabled by setting this to an empty value, but will render the telegraf
+      # and other agents unusable.
       bind: localhost:8094
 agents:
   # Data directory where Envoy stores downloaded agents and write agent configs

--- a/agents/filebeat_test.go
+++ b/agents/filebeat_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package agents_test
 
 import (
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/agents"
+	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -44,7 +45,7 @@ func TestFilebeatRunner_ProcessConfig_CreateModify(t *testing.T) {
 			runner := &agents.FilebeatRunner{}
 			err = runner.Load(dataPath)
 			require.NoError(t, err)
-			runner.LumberjackBind = "localhost:5555"
+			config.RegisterListenerAddress(config.LumberjackListener, "0.0.0.0:5555")
 
 			configure := &telemetry_edge.EnvoyInstructionConfigure{
 				AgentType: telemetry_edge.AgentType_FILEBEAT,
@@ -68,7 +69,8 @@ func TestFilebeatRunner_ProcessConfig_CreateModify(t *testing.T) {
 					require.NoError(t, err)
 
 					assert.Contains(t, string(content), "path: config.d/*.yml")
-					assert.Contains(t, string(content), "hosts: [\"localhost:5555\"]")
+					// confirm listener registration substituted bound host with loopback IP
+					assert.Contains(t, string(content), "hosts: [\"127.0.0.1:5555\"]")
 				} else if filepath.Base(path) == "a-b-c.yml" {
 					instanceConfigs++
 					content, err := ioutil.ReadFile(path)

--- a/agents/telegraf_test.go
+++ b/agents/telegraf_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"github.com/petergtz/pegomock"
 	"github.com/pkg/errors"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/agents"
 	"github.com/racker/salus-telemetry-envoy/agents/matchers"
 	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +60,7 @@ func TestTelegrafRunner_ProcessConfig_CreateModify(t *testing.T) {
 			defer os.RemoveAll(dataPath)
 
 			runner := &agents.TelegrafRunner{}
-			viper.Set(config.IngestTelegrafJsonBind, "localhost:8094")
+			config.RegisterListenerAddress(config.TelegrafJsonListener, "localhost:8094")
 			viper.Set(config.AgentsDefaultMonitoringInterval, 30*time.Second)
 			viper.Set(config.AgentsMaxFlushInterval, 31*time.Second)
 			err = runner.Load(dataPath)
@@ -90,7 +90,8 @@ func TestTelegrafRunner_ProcessConfig_CreateModify(t *testing.T) {
 			assert.Contains(t, string(content), "interval = \"30s\"")
 			assert.Contains(t, string(content), "flush_interval = \"31s\"")
 			assert.Contains(t, string(content), "outputs.socket_writer")
-			assert.Contains(t, string(content), "address = \"tcp://localhost:8094\"")
+			// confirm listener registration swapped out host with loopback IP
+			assert.Contains(t, string(content), "address = \"tcp://127.0.0.1:8094\"")
 			assert.Contains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
 			// optionally assert the per plugin interval
 			if tt.expectedInterval != "" {

--- a/agents/telegraf_test.go
+++ b/agents/telegraf_test.go
@@ -90,8 +90,7 @@ func TestTelegrafRunner_ProcessConfig_CreateModify(t *testing.T) {
 			assert.Contains(t, string(content), "interval = \"30s\"")
 			assert.Contains(t, string(content), "flush_interval = \"31s\"")
 			assert.Contains(t, string(content), "outputs.socket_writer")
-			// confirm listener registration swapped out host with loopback IP
-			assert.Contains(t, string(content), "address = \"tcp://127.0.0.1:8094\"")
+			assert.Contains(t, string(content), "address = \"tcp://localhost:8094\"")
 			assert.Contains(t, string(content), "[inputs]\n\n  [[inputs.mem]]\n")
 			// optionally assert the per plugin interval
 			if tt.expectedInterval != "" {

--- a/cmd/detached.go
+++ b/cmd/detached.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,16 @@ var detachedCmd = &cobra.Command{
 
 			detachChan := make(chan struct{}, 1)
 
-			// start agents runner/router like normal; however, nothing will actually send to the
+			// bind ingestors like normal
+			for _, ingestor := range ingest.Ingestors() {
+				err := ingestor.Bind()
+				if err != nil {
+					log.WithError(err).WithField("ingestor", ingestor).
+						Fatal("failed to connect ingestor")
+				}
+			}
+
+			// create agents runner/router like normal; however, nothing will actually send to the
 			// given detached channel
 			agentsRunner, err := agents.NewAgentsRunner(detachChan)
 			if err != nil {
@@ -51,22 +60,14 @@ var detachedCmd = &cobra.Command{
 			// use a "stub" egress "connection" that outputs metrics to stdout
 			connection := ambassador.NewStdoutEgressConnection()
 
-			// start ingestors like normal
+			// ...and start ingestors like normal
 			for _, ingestor := range ingest.Ingestors() {
-				err := ingestor.Bind(connection)
-				if err != nil {
-					log.WithError(err).WithField("ingestor", ingestor).
-						Fatal("failed to connect ingestor")
-				}
+				go ingestor.Start(ctx, connection)
 			}
 
 			// start everything like normal
 			go agentsRunner.Start(ctx)
 			go connection.Start(ctx, agents.SupportedAgents())
-
-			for _, ingestor := range ingest.Ingestors() {
-				go ingestor.Start(ctx)
-			}
 
 			// give the goroutines above a few cycles to actually be ready
 			time.Sleep(100 * time.Millisecond)

--- a/config/listeners.go
+++ b/config/listeners.go
@@ -17,7 +17,7 @@
 package config
 
 import (
-	"golang.org/x/tools/go/ssa/interp/testdata/src/strings"
+	"strings"
 	"sync"
 )
 

--- a/config/listeners.go
+++ b/config/listeners.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"log"
+	"net"
+	"sync"
+)
+
+const (
+	TelegrafJsonListener = "telegraf-json"
+	LumberjackListener   = "lumberjack"
+)
+
+var listenerAddresses sync.Map
+
+func RegisterListenerAddress(name string, address string) {
+	// The given address is relative to the binding, so it might contain the special "all interfaces"
+	// address of 0.0.0.0. As such, we need to pick apart and rebuild an address suitable for
+	// telling local agents how to connect to the given bound address.
+
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	listenerAddresses.Store(name, "127.0.0.1:"+port)
+}
+
+func GetListenerAddress(name string) string {
+	if address, ok := listenerAddresses.Load(name); ok {
+		return address.(string)
+	} else {
+		return ""
+	}
+}

--- a/config/listeners.go
+++ b/config/listeners.go
@@ -33,6 +33,8 @@ func RegisterListenerAddress(name string, address string) {
 	// The given address is relative to the binding, so it might contain the special "all interfaces"
 	// address of 0.0.0.0. As such, we need to pick apart and rebuild an address suitable for
 	// telling local agents how to connect to the given bound address.
+	// This will allow a server without an envoy to send its metrics to a
+	// different server's envoy/ingestor.
 
 	_, port, err := net.SplitHostPort(address)
 	if err != nil {

--- a/config/listeners_test.go
+++ b/config/listeners_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config_test
+
+import (
+	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRegisterListenerAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{name: "localhost", address: "localhost:1234", expected: "localhost:1234"},
+		{name: "bindall", address: "0.0.0.0:1234", expected: "127.0.0.1:1234"},
+		{name: "external", address: "10.1.2.3:1234", expected: "10.1.2.3:1234"},
+		{name: "bindall_zeroes", address: "10.0.0.0:1234", expected: "10.0.0.0:1234"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.RegisterListenerAddress(tt.name, tt.address)
+			address := config.GetListenerAddress(tt.name)
+			assert.Equal(t, tt.expected, address)
+		})
+	}
+}

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package ingest
@@ -24,8 +22,8 @@ import (
 )
 
 type Ingestor interface {
-	Bind(conn ambassador.EgressConnection) error
-	Start(ctx context.Context)
+	Bind() error
+	Start(ctx context.Context, connection ambassador.EgressConnection)
 }
 
 var ingestors []Ingestor

--- a/ingest/lumberjack.go
+++ b/ingest/lumberjack.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,18 @@ import (
 	"encoding/json"
 	"github.com/elastic/go-lumber/lj"
 	"github.com/elastic/go-lumber/server"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
+	"github.com/pkg/errors"
 	"github.com/racker/salus-telemetry-envoy/ambassador"
 	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"net"
 )
 
 type Lumberjack struct {
 	egressConn ambassador.EgressConnection
+	listener   net.Listener
 	server     server.Server
 }
 
@@ -41,23 +44,42 @@ func init() {
 	registerIngestor(&Lumberjack{})
 }
 
-func (l *Lumberjack) Bind(connection ambassador.EgressConnection) error {
-	l.egressConn = connection
-
+func (l *Lumberjack) Bind() error {
 	address := viper.GetString(config.IngestLumberjackBind)
-
-	var err error
-	l.server, err = server.ListenAndServe(address, server.V2(true))
-	if err != nil {
-		return err
+	// check if ingest is disabled via absent config
+	if address == "" {
+		return nil
 	}
 
-	log.WithField("address", address).Debug("Listening for lumberjack")
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return errors.Wrap(err, "failed to bind lumberjack listener")
+	}
+
+	config.RegisterListenerAddress(config.LumberjackListener, listener.Addr().String())
+	l.listener = listener
+
+	log.WithField("address", address).Debug("listening for lumberjack")
 	return nil
 }
 
 // Start processes incoming lumberjack batches
-func (l *Lumberjack) Start(ctx context.Context) {
+func (l *Lumberjack) Start(ctx context.Context, connection ambassador.EgressConnection) {
+	if l.listener == nil {
+		log.Debug("lumberjack ingest is disabled")
+		return
+	}
+	l.egressConn = connection
+
+	var err error
+	l.server, err = server.ListenAndServeWith(func(network, addr string) (net.Listener, error) {
+		// provide our own binder so we can intercept and return the listener that was pre-bound
+		return l.listener, err
+	}, l.listener.Addr().String(), server.V2(true))
+	if err != nil {
+		log.WithError(err).Fatal("unable to start lumberjack server")
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package ingest
 import (
 	"context"
 	"fmt"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/ambassador"
 	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"net"
@@ -42,22 +42,22 @@ func init() {
 	registerIngestor(&PerfTestIngestor{})
 }
 
-func (p *PerfTestIngestor) Bind(conn ambassador.EgressConnection) error {
+func (p *PerfTestIngestor) Bind() error {
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return nil
 	}
 	log.Info("entering perfTest mode")
-	p.egressConn = conn
 	p.metricsPerMinute = 60
 	p.floatsPerMetric = 10
 	p.newRateC = make(chan int)
 	return nil
 }
 
-func (p *PerfTestIngestor) Start(ctx context.Context) {
+func (p *PerfTestIngestor) Start(ctx context.Context, conn ambassador.EgressConnection) {
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return
 	}
+	p.egressConn = conn
 
 	p.ticker = time.NewTicker(time.Duration(int64(time.Minute) / int64(p.metricsPerMinute)))
 	go p.startPerfTestServer()

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -43,11 +43,11 @@ func TestPerfTestIngestor(t *testing.T) {
 	require.NoError(t, err)
 	viper.Set(config.PerfTestPort, port)
 	ingestor := &ingest.PerfTestIngestor{}
-	err = ingestor.Bind(mockEgressConnection)
+	err = ingestor.Bind()
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go ingestor.Start(ctx, connection)
+	go ingestor.Start(ctx, mockEgressConnection)
 	defer cancel()
 
 	// allow for ingestor to bind and webserver to start

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"github.com/petergtz/pegomock"
 	"github.com/phayes/freeport"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/config"
 	"github.com/racker/salus-telemetry-envoy/ingest"
 	"github.com/racker/salus-telemetry-envoy/ingest/matchers"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ func TestPerfTestIngestor(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go ingestor.Start(ctx)
+	go ingestor.Start(ctx, connection)
 	defer cancel()
 
 	// allow for ingestor to bind and webserver to start

--- a/ingest/telegraf_json.go
+++ b/ingest/telegraf_json.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/pkg/errors"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/ambassador"
 	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"net"
@@ -52,21 +52,31 @@ func init() {
 	registerIngestor(&TelegrafJson{})
 }
 
-func (t *TelegrafJson) Bind(conn ambassador.EgressConnection) error {
-	bind := viper.GetString(config.IngestTelegrafJsonBind)
-
-	listener, err := net.Listen("tcp", bind)
-	if err != nil {
-		return errors.Wrap(err, "failed to bind telegraf json listenener")
+func (t *TelegrafJson) Bind() error {
+	address := viper.GetString(config.IngestTelegrafJsonBind)
+	// check if ingest is disabled via absent config
+	if address == "" {
+		return nil
 	}
 
-	t.listener = listener
-	t.egressConn = conn
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return errors.Wrap(err, "failed to bind telegraf json listener")
+	}
 
+	config.RegisterListenerAddress(config.TelegrafJsonListener, listener.Addr().String())
+	t.listener = listener
+
+	log.WithField("address", address).Debug("listening for telegraf json")
 	return nil
 }
 
-func (t *TelegrafJson) Start(ctx context.Context) {
+func (t *TelegrafJson) Start(ctx context.Context, connection ambassador.EgressConnection) {
+	if t.listener == nil {
+		log.Debug("telegraf json ingest is disabled")
+		return
+	}
+	t.egressConn = connection
 
 	t.metrics = make(chan *telegrafJsonMetric, telegrafJsonMetricChanSize)
 	go t.acceptConnections(ctx)

--- a/ingest/telegraf_json_test.go
+++ b/ingest/telegraf_json_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import (
 	"context"
 	"github.com/petergtz/pegomock"
 	"github.com/phayes/freeport"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/config"
 	"github.com/racker/salus-telemetry-envoy/ingest"
 	"github.com/racker/salus-telemetry-envoy/ingest/matchers"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,7 +94,7 @@ func TestTelegrafJson_Start(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go ingestor.Start(ctx)
+			go ingestor.Start(ctx, connection)
 			defer cancel()
 
 			// allow for ingestor to bind and accept connections

--- a/ingest/telegraf_json_test.go
+++ b/ingest/telegraf_json_test.go
@@ -90,11 +90,11 @@ func TestTelegrafJson_Start(t *testing.T) {
 			ingestor := &ingest.TelegrafJson{}
 			addr := net.JoinHostPort("localhost", strconv.Itoa(port))
 			viper.Set(config.IngestTelegrafJsonBind, addr)
-			err = ingestor.Bind(mockEgressConnection)
+			err = ingestor.Bind()
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			go ingestor.Start(ctx, connection)
+			go ingestor.Start(ctx, mockEgressConnection)
 			defer cancel()
 
 			// allow for ingestor to bind and accept connections


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-748 and prepares for new line protocol ingestor to be added for https://jira.rax.io/browse/SALUS-594

# What

We found on some systems where logstash was running that the lumberjack binding would fail since the equivalent logstash plugin was already bound at the standard port. That made me realize that we should ensure a few variations of ingest config to be allowed:

- disabling an ingestor entirely by setting a blank bind address
- binding to "all interfaces" by specifying `0.0.0.0` as the ingestor bind address, yet converting to `127.0.0.1` when the agent runner is looking up what to use for agent configs
- binding to any available port by allowing a 0 or absent port value

All of this also gets ready for me to add a line protocol ingest type to be used in conjunction with https://github.com/racker/salus-packages-agent/pull/1

# How

Most of the code changes are code cleanup to ensure the Ingestor Bind and Start method are consistently doing just what they were intended to be doing. With that the agent lookup of registered listener address could be consistently handled.

## How to test

Existing unit tests