### PR TITLE
Support detached test-monitor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ the scenario currently running on your system.
 
 Envoy includes a sub-command called `detached` that can be used to test the Envoy's agent download and configuration mechanism without connecting to an Ambassador. 
 
-The sub-command replaces the support of the Ambassador with two mechanisms:
+The sub-command replaces the support of the Ambassador with the following mechanisms:
 
 - Ingested telemetry (metrics and logs) is encoded to JSON and output to stdout
 - Agent installation and configuration instructions are loaded from a JSON file
+- Test-Monitor instructions are executed, but the results are output as an info-level log
 
 The instructions file must be structured for unmarshaling into the `DetachedInstructions` protobuf message, declared in the Telemetry Edge protocol. [This example file](cmd/testdata/instructions.json) installs an instance of telegraf and configures a CPU monitor.
 

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -342,7 +342,7 @@ func (tr *TelegrafRunner) ProcessTestMonitor(correlationId string, content strin
 	var cmdOut []byte
 	for attempt := 0; attempt < telegrafMaxTestMonitorRetries; attempt++ {
 		cmdOut, err = testConfigRunner.RunCommand(hostPort, tr.exePath(), tr.basePath, timeout)
-		if len(cmdOut) != 0 {
+		if err != nil || len(cmdOut) != 0 {
 			break
 		}
 		// wait just a bit between each try

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -344,19 +344,19 @@ func (tr *TelegrafRunner) ProcessTestMonitor(correlationId string, content strin
 			exitErrMessage := err.Error()
 			// checking error's message is portable and easy way to determine if the exec timeout was exceeded
 			if exitErrMessage == "signal: killed" {
-				results.Errors = append(results.Errors, "Command: took too long to run")
+				results.Errors = append(results.Errors, "Command took too long to run")
 			} else {
-				results.Errors = append(results.Errors, "Command: "+err.Error())
+				results.Errors = append(results.Errors, "Command failed: "+err.Error())
 			}
-			results.Errors = append(results.Errors, "CommandStderr: "+string(exitErr.Stderr))
+			results.Errors = append(results.Errors, "Command failed with error output: "+string(exitErr.Stderr))
 		} else {
-			results.Errors = append(results.Errors, "Command: "+err.Error())
+			results.Errors = append(results.Errors, "Command failed: "+err.Error())
 		}
 	} else {
 		// ... and process output
 		parsedMetrics, err := lineproto.ParseInfluxLineProtocolMetrics(cmdOut)
 		if err != nil {
-			results.Errors = append(results.Errors, "Parse: "+err.Error())
+			results.Errors = append(results.Errors, "Failed to parse telegraf output: "+err.Error())
 		} else {
 			// Wrap up the named tag-value metrics into the general metrics type
 			results.Metrics = make([]*telemetry_edge.Metric, len(parsedMetrics))

--- a/ambassador/detached_runner.go
+++ b/ambassador/detached_runner.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/agents"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	log "github.com/sirupsen/logrus"
 	"os"
 )
@@ -68,6 +68,9 @@ func (r *DetachedRunner) Load(instructionsFilePath string) error {
 			r.agentsRouter.ProcessInstall(instruction.GetInstall())
 		} else if instruction.GetConfigure() != nil {
 			r.agentsRouter.ProcessConfigure(instruction.GetConfigure())
+		} else if instruction.GetTestMonitor() != nil {
+			results := r.agentsRouter.ProcessTestMonitor(instruction.GetTestMonitor())
+			log.WithField("results", results).Info("processed detached test-monitor")
 		} else {
 			log.WithField("instruction", instruction).Warn("Unexpected instruction type")
 		}

--- a/cmd/testdata/instructions-telegraf-testmonitor.json
+++ b/cmd/testdata/instructions-telegraf-testmonitor.json
@@ -1,16 +1,6 @@
 {
   "instructions": [
     {
-      "install": {
-        "agent": {
-          "type": "TELEGRAF",
-          "version": "1.13.2"
-        },
-        "url": "https://homebrew.bintray.com/bottles/telegraf-1.13.2.mojave.bottle.tar.gz",
-        "exe": "telegraf/1.13.2/bin/telegraf"
-      }
-    },
-    {
       "testMonitor": {
         "agentType": "TELEGRAF",
         "content": "{\"type\": \"cpu\",\"percpu\":false,\"totalcpu\":true,\"collectCpuTime\":false,\"reportActive\":false}",

--- a/cmd/testdata/instructions-telegraf-testmonitor.json
+++ b/cmd/testdata/instructions-telegraf-testmonitor.json
@@ -1,0 +1,22 @@
+{
+  "instructions": [
+    {
+      "install": {
+        "agent": {
+          "type": "TELEGRAF",
+          "version": "1.13.2"
+        },
+        "url": "https://homebrew.bintray.com/bottles/telegraf-1.13.2.mojave.bottle.tar.gz",
+        "exe": "telegraf/1.13.2/bin/telegraf"
+      }
+    },
+    {
+      "testMonitor": {
+        "agentType": "TELEGRAF",
+        "content": "{\"type\": \"cpu\",\"percpu\":false,\"totalcpu\":true,\"collectCpuTime\":false,\"reportActive\":false}",
+        "timeout": 30,
+        "correlationId": "detached-123"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-785

# What

Tried recreating https://gist.github.com/jjbuchan/32d3de48dd4a8a4b493a6983a3f74c30 by adding support for detached test-monitor instructions and running that 10-20 times.

# How

Added support for test-monitor instructions to the existing detached runner logic and just log the returned results. Note: control-C needs to be used still to stop the envoy since detached mode also needs to support ongoing monitor runs.

Since I couldn't recreate the reported problem, the best compromise I could find was to improve the error message prefixes since admittedly "Parse:" wasn't very helpful.

## How to test

From the `dev` directory, ran envoy with the arguments `detached --data-path=data-telemetry-envoy-detached --instructions=../apps/envoy/cmd/testdata/instructions-telegraf-testmonitor.json --debug`