### PR TITLE
fix perf test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,17 @@ An example invocation of this sub-command is:
 With this sub-command, logs are output to stderr so that file descriptor redirects can be used to separate the envoy logging from the posted telemetry content.
 
 ### Running perf test mode
+Adding the following to the config file starts the envoy in perf test mode at port 8100, with 10 metrics per minute and 20 floats per metric
 ```bash
-telemetry-envoy run --perf-test-port=8100 --config=envoy-config-provided.yml
+perfTest:
+  port: 8100
+  metricsPerMinute: 10
+  floatsPerMetric: 20
 ```
-starts the envoy in perf test mode at port 8100
 
 The rate of metrics generated can be changed with a rest call like so:
 ```bash
-curl http://localhost:8100/ -d metricsPerMinute=15 -d floatsPerMetric=20
+curl http://localhost:8100/ -d metricsPerMinute=10 -d floatsPerMetric=20
 ```
 ### Locally testing gRPC/proto changes
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,8 +54,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.telemetry-envoy.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output")
 
-	rootCmd.PersistentFlags().Int("perf-test-port", 0, "Enable perf test mode/port")
-	viper.BindPFlag(config.PerfTestPort, rootCmd.PersistentFlags().Lookup("perf-test-port"))
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))
 

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -32,7 +32,9 @@ const (
 	AmbassadorAddress               = "ambassador.address"
 	ResourceId                      = "resource_id"
 	Zone                            = "zone"
-	PerfTestPort                    = "perf_test_port"
+	PerfTestPort                    = "perfTest.port"
+	PerfTestMetricsPerMinute        = "perfTest.metricsPerMinute"
+	PerfTestFloatsPerMetric         = "perfTest.metricsPerMetric"
 
 	DefaultAgentsDataPath                  = "/var/lib/telemetry-envoy"
 	DefaultAgentsTestMonitorTimeout        = 30 * time.Second

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -43,12 +43,19 @@ func init() {
 }
 
 func (p *PerfTestIngestor) Bind() error {
+	log.Infof("gbjinfo: %d\n", viper.GetInt(config.PerfTestPort))
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return nil
 	}
-	log.Info("entering perfTest mode")
-	p.metricsPerMinute = 60
-	p.floatsPerMetric = 10
+	if viper.GetInt(config.PerfTestMetricsPerMinute) == 0 {
+		p.metricsPerMinute = 60
+		p.floatsPerMetric = 10
+	} else {
+		p.metricsPerMinute = viper.GetInt(config.PerfTestMetricsPerMinute)
+		p.floatsPerMetric = viper.GetInt(config.PerfTestFloatsPerMetric)
+	}
+	log.Infof("entering perfTest mode.  metricsPerMinute %d, floatsPerMetric %d\n",
+		p.metricsPerMinute, p.floatsPerMetric)
 	p.newRateC = make(chan int)
 	return nil
 }
@@ -125,8 +132,10 @@ func (p *PerfTestIngestor) handler(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("metricsPerMinute or floatsPerMetric parameter required"))
 		return
 	}
-	_, _ = w.Write([]byte(fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d",
-		metricsCount, p.floatsPerMetric)))
+	output := fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d\n",
+		metricsCount, p.floatsPerMetric)
+	log.Infof(output)
+	_, _ = w.Write([]byte(output))
 	return
 }
 

--- a/ingest/perf_test_ingestor.go
+++ b/ingest/perf_test_ingestor.go
@@ -43,7 +43,6 @@ func init() {
 }
 
 func (p *PerfTestIngestor) Bind() error {
-	log.Infof("gbjinfo: %d\n", viper.GetInt(config.PerfTestPort))
 	if viper.GetInt(config.PerfTestPort) == 0 {
 		return nil
 	}

--- a/ingest/perf_test_ingestor_test.go
+++ b/ingest/perf_test_ingestor_test.go
@@ -79,5 +79,5 @@ func TestPerfTestIngestor(t *testing.T) {
 	assert.Equal(t, resp.StatusCode, 200)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d", metricsPerMinute, floatsPerMetric), string(body))
+	assert.Equal(t, fmt.Sprintf("metricsPerMinute set to %d, floatsPerMetric set to %d\n", metricsPerMinute, floatsPerMetric), string(body))
 }


### PR DESCRIPTION
# Resolves
part of:
https://jira.rax.io/projects/SALUS/issues/SALUS-820

# What

Allows perf test mode to be configured from the config file in addition to the webservice.

# How

Adds config file variables for perf test fields: metricsPerMinute, and floatsPerMetric

## How to test

unit tests pass
