### PR TITLE
now checks that connection is attached before posting metrics/log events

### DIFF
--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -275,6 +275,7 @@ func (c *StandardEgressConnection) attach() error {
 
 func (c *StandardEgressConnection) PostLogEvent(agentType telemetry_edge.AgentType, jsonContent string) {
 	if !c.attached {
+		log.Debug("not posting log event to unattached connection.")
 		return
 	}
 	callCtx, callCancel := context.WithTimeout(c.outgoingContext, c.GrpcCallLimit)
@@ -292,6 +293,7 @@ func (c *StandardEgressConnection) PostLogEvent(agentType telemetry_edge.AgentTy
 
 func (c *StandardEgressConnection) PostMetric(metric *telemetry_edge.Metric) {
 	if !c.attached {
+		log.Debug("not posting metric event to unattached connection.")
 		return
 	}
 	callCtx, callCancel := context.WithTimeout(c.outgoingContext, c.GrpcCallLimit)

--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -21,10 +21,10 @@ import (
 	"crypto/tls"
 	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
-	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/racker/salus-telemetry-envoy/agents"
 	"github.com/racker/salus-telemetry-envoy/auth"
 	"github.com/racker/salus-telemetry-envoy/config"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -99,6 +99,7 @@ type StandardEgressConnection struct {
 	// outgoingContext is used by gRPC client calls to build the final call context
 	outgoingContext          context.Context
 	networkDialOptionCreator NetworkDialOptionCreator
+	attached                 bool
 }
 
 func init() {
@@ -251,10 +252,11 @@ func (c *StandardEgressConnection) attach() error {
 
 	go c.watchForInstructions(outgoingCtx, errChan, instructions)
 	go c.sendKeepAlives(outgoingCtx, errChan)
-
+	c.attached = true
 	for {
 		select {
 		case <-outgoingCtx.Done():
+			c.attached = false
 			log.Debug("closing attach receiver stream")
 			err := instructions.CloseSend()
 			if err != nil {
@@ -263,6 +265,7 @@ func (c *StandardEgressConnection) attach() error {
 			return errors.New("closed")
 
 		case err := <-errChan:
+			c.attached = false
 			log.WithError(err).Warn("terminating connection due to error")
 			c.detachChan <- struct{}{}
 			cancelFunc()
@@ -271,6 +274,9 @@ func (c *StandardEgressConnection) attach() error {
 }
 
 func (c *StandardEgressConnection) PostLogEvent(agentType telemetry_edge.AgentType, jsonContent string) {
+	if !c.attached {
+		return
+	}
 	callCtx, callCancel := context.WithTimeout(c.outgoingContext, c.GrpcCallLimit)
 	defer callCancel()
 
@@ -285,6 +291,9 @@ func (c *StandardEgressConnection) PostLogEvent(agentType telemetry_edge.AgentTy
 }
 
 func (c *StandardEgressConnection) PostMetric(metric *telemetry_edge.Metric) {
+	if !c.attached {
+		return
+	}
 	callCtx, callCancel := context.WithTimeout(c.outgoingContext, c.GrpcCallLimit)
 	defer callCancel()
 


### PR DESCRIPTION
i was running into a race condition where sometimes metrics were being posted to an unattatched connection which was causing a nil pointer panic.