### PR TITLE
Added tenant_id to config and included in cert request

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ The following is an example configuration file that can be used as a starting po
 ```yaml
 # The identifier of the resource where this Envoy is running
 # The convention is a type:value, but is not required.
+# Can also be passed on the command-line as --resource-id
+# Can also be passed via the environment variable ENVOY_RESOURCE_ID
 resource_id: "type:value"
+# The tenant ID of the resource where this Envoy is running.
+# Can also be passed on the command-line as --tenant-id
+# Can also be passed via the environment variable ENVOY_TENANT_ID
+tenant_id: ""
 # Additional key:value string pairs that will be included with Envoy attachment.
 labels:
   #environment: production

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,9 @@ func init() {
 
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))
+
+	rootCmd.PersistentFlags().String("tenant-id", "", "Tenant ID of the resource where this Envoy is running")
+	viper.BindPFlag(config.TenantId, rootCmd.PersistentFlags().Lookup("tenant-id"))
 
 	rootCmd.PersistentFlags().String("data-path", config.DefaultAgentsDataPath,
 		"Data directory where Envoy stores downloaded agents and write agent configs")

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -31,6 +31,7 @@ const (
 	IngestLineProtocolBind          = "ingest.lineProtocol.bind"
 	AmbassadorAddress               = "ambassador.address"
 	ResourceId                      = "resource_id"
+	TenantId                        = "tenant_id"
 	Zone                            = "zone"
 	PerfTestPort                    = "perfTest.port"
 	PerfTestMetricsPerMinute        = "perfTest.metricsPerMinute"


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-602

# What

- Since Identity users may potentially be associated with more than one tenant, the authentication cert request should really be qualified by tenant to avoid ambiguity
- The Repose configuration currently differs for the auth service vs admin/public APIs since the latter use the typical Rackspace API paths with a version prefix and tenant in the path. It would be good to use consistent configuration across all of the externally facing APIs

# How

Added `tenant_id` as a top level field in the Envoy config and also included command-line (and env var) mapping for that config field. When the Envoy is using the auth service for client cert retrieval (which is the case for production deploys) it requires the tenant_id be set and then uses that to form the versioned/tenant URL.

# How to test

Updated existing unit tests

# Depends on

https://github.com/racker/salus-telemetry-auth-service/pull/29