### PR TITLE
Improved handling of CURRENT symlink during agent upgrades

### DIFF
--- a/agents/agents.go
+++ b/agents/agents.go
@@ -59,7 +59,7 @@ type SpecificAgentRunner interface {
 	EnsureRunningState(ctx context.Context, applyConfigs bool)
 	// PostInstall is invoked after installation of a new agent version and allows the
 	// specific agent runner a chance to tweak capabilities assigned to the executable
-	PostInstall() error
+	PostInstall(agentVersionPath string) error
 	PurgeConfig() error
 	ProcessConfig(configure *telemetry_edge.EnvoyInstructionConfigure) error
 	ProcessTestMonitor(correlationId string, content string, timeout time.Duration) (*telemetry_edge.TestMonitorResults, error)

--- a/agents/filebeat.go
+++ b/agents/filebeat.go
@@ -73,7 +73,7 @@ func (fbr *FilebeatRunner) SetCommandHandler(handler CommandHandler) {
 	fbr.commandHandler = handler
 }
 
-func (fbr *FilebeatRunner) PostInstall() error {
+func (fbr *FilebeatRunner) PostInstall(string) error {
 	return nil
 }
 

--- a/agents/oracle.go
+++ b/agents/oracle.go
@@ -33,15 +33,14 @@ const (
 )
 
 type OracleRunner struct {
-	basePath            string
-	running             *AgentRunningContext
-	commandHandler      CommandHandler
+	basePath       string
+	running        *AgentRunningContext
+	commandHandler CommandHandler
 }
 
 func init() {
 	registerSpecificAgentRunner(telemetry_edge.AgentType_ORACLE, &OracleRunner{})
 }
-
 
 func (o *OracleRunner) Load(agentBasePath string) error {
 	o.basePath = agentBasePath
@@ -85,7 +84,7 @@ func (o *OracleRunner) EnsureRunningState(ctx context.Context, applyConfigs bool
 	log.Info("started oracle agent")
 }
 
-func (o *OracleRunner) PostInstall() error {
+func (o *OracleRunner) PostInstall(string) error {
 	return nil
 }
 
@@ -135,7 +134,6 @@ func (o *OracleRunner) ProcessConfig(configure *telemetry_edge.EnvoyInstructionC
 	return nil
 }
 
-
 func (o *OracleRunner) writeConfigFile(path string, op *telemetry_edge.ConfigurationOp) error {
 	var configMap map[string]interface{}
 	err := json.Unmarshal([]byte(op.GetContent()), &configMap)
@@ -170,4 +168,3 @@ func (o *OracleRunner) Stop() {
 	o.running = nil
 
 }
-

--- a/agents/pkgagent.go
+++ b/agents/pkgagent.go
@@ -58,7 +58,7 @@ func (pr *PackagesAgentRunner) PurgeConfig() error {
 	return purgeConfigsDirectory(pr.basePath)
 }
 
-func (pr *PackagesAgentRunner) PostInstall() error {
+func (pr *PackagesAgentRunner) PostInstall(string) error {
 	// no adjustments needed
 	return nil
 }

--- a/agents/telegraf.go
+++ b/agents/telegraf.go
@@ -193,8 +193,8 @@ func (tr *TelegrafRunner) handleTelegrafConfigurationOp(op *telemetry_edge.Confi
 	return false
 }
 
-func (tr *TelegrafRunner) PostInstall() error {
-	resolvedExePath := path.Join(tr.basePath, tr.exePath())
+func (tr *TelegrafRunner) PostInstall(agentVersionPath string) error {
+	resolvedExePath := path.Join(agentVersionPath, binSubpath, "telegraf")
 
 	err := addNetRawCapabilities(resolvedExePath)
 	if err != nil {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-800

# What

The handling of the `CURRENT` symlink that points to the currently installed agent-version directory was a bit brittle.

# How

Improved the logic check for symlink's existence and/or what target directory (version) an existing symlink is referencing. It only creates or removes/recreates the symlink when necessary.

The resulting diff looks a bit hard to read, so you may want to use the side-by-side mode or review the resulting`func (ar *StandardAgentsRouter) ProcessInstall` code. 

## How to test

Added more unit testing to specifically ensure an agent installation that switches versions works properly.