### PR TITLE
Added stress-connections command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ When the [Go build tag](https://golang.org/pkg/go/build/) `dev` is enabled with 
 
 ```
 ./telemetry-envoy stress-connections --config=envoy-config-provided.yml \
-  --connection-count=5 --metrics-per-minute=20
+  --connection-count=5 --metrics-per-minute=20 --connections-delay=10s
 ```
 
 This intended use for this mode is stress-testing and profiling the Envoy-Ambassador connectivity performance. It runs a stripped down Envoy that does the following:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,25 @@ The rate of metrics generated can be changed with a rest call like so:
 ```bash
 curl http://localhost:8100/ -d metricsPerMinute=10 -d floatsPerMetric=20
 ```
+
+### Running stress-connections mode
+
+When the [Go build tag](https://golang.org/pkg/go/build/) `dev` is enabled with `-tags dev`, then the sub-command `stress-connections` is available for use, such as:
+
+```
+./telemetry-envoy stress-connections --config=envoy-config-provided.yml \
+  --connection-count=5 --metrics-per-minute=20
+```
+
+This intended use for this mode is stress-testing and profiling the Envoy-Ambassador connectivity performance. It runs a stripped down Envoy that does the following:
+- Skips all creation of ingestors
+- Skips all registration of agent runners
+- Establishes a configurable number of connections (`--connection-count`) to the Ambassador specified in the given `--config` file. Each connection:
+    - Is assigned a resource ID `resource-{index}` where `{index}` starts at zero
+    - Gets a fabricated metric posted at the requested rate (`--metrics-per-minute`). The metric is named `stress_connection` and contains a single floating-point field named `duration` with a random value. The metric generator randomly staggers the start time for each connection to ensure activity is evenly spread across connections.
+
+> NOTE: In IntelliJ, the build tag preferences are located in "Languages & Framework > Go > Build Tags & Vendoring". The run config also has an option "Use all custom build tags" that needs to be enabled.
+
 ### Locally testing gRPC/proto changes
 
 If making local changes to the gRPC/proto files in `salus-telemetry-protocol`, you'll need to make a temporary change to `go.mod` to reference those. Add the following after the `require` block:

--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -148,7 +148,7 @@ func (c *StandardEgressConnection) Start(ctx context.Context, supportedAgents []
 
 	log.WithFields(log.Fields{
 		"resourceId": c.resourceId,
-	}).Debug("Starting connection with identifier")
+	}).Debug("Starting connection to Ambassador")
 
 	c.ctx = ctx
 	c.supportedAgents = supportedAgents

--- a/ambassador/connection.go
+++ b/ambassador/connection.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,14 +141,15 @@ func NewEgressConnection(agentsRunner agents.Router, detachChan chan<- struct{},
 		return nil, err
 	}
 
-	log.WithFields(log.Fields{
-		"resourceId": resourceId,
-	}).Debug("Starting connection with identifier")
-
 	return connection, nil
 }
 
 func (c *StandardEgressConnection) Start(ctx context.Context, supportedAgents []telemetry_edge.AgentType) {
+
+	log.WithFields(log.Fields{
+		"resourceId": c.resourceId,
+	}).Debug("Starting connection with identifier")
+
 	c.ctx = ctx
 	c.supportedAgents = supportedAgents
 

--- a/ambassador/connection_dev.go
+++ b/ambassador/connection_dev.go
@@ -1,0 +1,24 @@
+// +build dev
+
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ambassador
+
+// SetResourceId is only used in dev mode to simulate multiple Envoy/resources
+func SetResourceId(egress EgressConnection, resourceId string) {
+	egress.(*StandardEgressConnection).resourceId = resourceId
+}

--- a/cmd/detached.go
+++ b/cmd/detached.go
@@ -1,3 +1,5 @@
+// +build dev
+
 /*
  * Copyright 2020 Rackspace US, Inc.
  *

--- a/cmd/stressconnections.go
+++ b/cmd/stressconnections.go
@@ -93,6 +93,10 @@ func init() {
 	stressConnectionsCmd.Flags().Int("metrics-per-minute", 20,
 		"Number of metrics to post per minute per connection")
 	viper.BindPFlag("stress.metrics-per-minute", stressConnectionsCmd.Flag("metrics-per-minute"))
+
+	stressConnectionsCmd.Flags().Bool("stagger-metrics", true,
+		"When true, delay the initial metric sent by each connection by a random amount of the interval")
+	viper.BindPFlag("stress.stagger-metrics", stressConnectionsCmd.Flag("stagger-metrics"))
 }
 
 func sendMetrics(ctx context.Context, resourceId string, monitorId string, connection ambassador.EgressConnection) {
@@ -100,10 +104,12 @@ func sendMetrics(ctx context.Context, resourceId string, monitorId string, conne
 
 	interval := time.Minute / time.Duration(metricsPerMinute)
 
-	// sleep a random part of one interval
-	time.Sleep(time.Duration(
-		rand.Int63n(int64(interval)),
-	))
+	if viper.GetBool("stress.stagger-metrics") {
+		// sleep a random part of one interval
+		time.Sleep(time.Duration(
+			rand.Int63n(int64(interval)),
+		))
+	}
 
 	ticker := time.NewTicker(interval)
 

--- a/cmd/stressconnections.go
+++ b/cmd/stressconnections.go
@@ -118,7 +118,7 @@ func sendMetric(ts time.Time, resourceId string, connection ambassador.EgressCon
 		Variant: &telemetry_edge.Metric_NameTagValue{
 			NameTagValue: &telemetry_edge.NameTagValueMetric{
 				Name:      "stress_connection",
-				Timestamp: ts.Unix(),
+				Timestamp: ts.Unix() * 1000,
 				Tags:      tags,
 				Fvalues:   fvalues,
 			},

--- a/cmd/stressconnections.go
+++ b/cmd/stressconnections.go
@@ -1,0 +1,144 @@
+// +build dev
+
+// NOTE: that build tag ^ ensures that end users won't get this dev-only command
+// in the published Envoy.
+
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/racker/salus-telemetry-envoy/ambassador"
+	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"math/rand"
+	"time"
+)
+
+var stressConnectionsCmd = &cobra.Command{
+	Use:   "stress-connections",
+	Short: "Run the Envoy in a connection-only mode with simulated metrics posted",
+	Run: func(cmd *cobra.Command, args []string) {
+		handleInterrupts(func(ctx context.Context) {
+
+			detachChan := make(chan struct{}, 1)
+			idGenerator := ambassador.NewIdGenerator()
+
+			networkDialOptionCreator := ambassador.NewNetworkDialOptionCreator()
+
+			connectionCount := viper.GetInt("stress.connection-count")
+			connections := make([]ambassador.EgressConnection, connectionCount)
+			for i := 0; i < connectionCount; i++ {
+				connection, err := ambassador.NewEgressConnection(
+					&mockAgentsRouter{},
+					detachChan,
+					idGenerator,
+					networkDialOptionCreator,
+				)
+				if err != nil {
+					log.Fatal(err)
+				}
+				resourceId := fmt.Sprintf("resource-%04d", i)
+				ambassador.SetResourceId(connection, resourceId)
+
+				go connection.Start(ctx, []telemetry_edge.AgentType{
+					telemetry_edge.AgentType_TELEGRAF,
+				})
+
+				connections[i] = connection
+
+				go sendMetrics(ctx, resourceId, connection)
+			}
+
+		})
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stressConnectionsCmd)
+
+	stressConnectionsCmd.Flags().Int("connection-count", 5,
+		"Number of Ambassador connections to setup")
+	viper.BindPFlag("stress.connection-count", stressConnectionsCmd.Flag("connection-count"))
+
+	stressConnectionsCmd.Flags().Int("metrics-per-minute", 20,
+		"Number of metrics to post per minute per connection")
+	viper.BindPFlag("stress.metrics-per-minute", stressConnectionsCmd.Flag("metrics-per-minute"))
+}
+
+func sendMetrics(ctx context.Context, resourceId string, connection ambassador.EgressConnection) {
+	metricsPerMinute := viper.GetInt("stress.metrics-per-minute")
+
+	interval := time.Minute / time.Duration(metricsPerMinute)
+
+	// sleep a random part of one interval
+	time.Sleep(time.Duration(
+		rand.Int63n(int64(interval)),
+	))
+
+	ticker := time.NewTicker(interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case ts := <-ticker.C:
+			sendMetric(ts, resourceId, connection)
+		}
+	}
+}
+
+func sendMetric(ts time.Time, resourceId string, connection ambassador.EgressConnection) {
+	fvalues := make(map[string]float64)
+	fvalues["duration"] = rand.Float64() * 1000.0
+	tags := make(map[string]string)
+	// this tag is mostly here so that debug logs reveal what resource would be "posting" each metric
+	tags["simulating_resource"] = resourceId
+	metric := &telemetry_edge.Metric{
+		Variant: &telemetry_edge.Metric_NameTagValue{
+			NameTagValue: &telemetry_edge.NameTagValueMetric{
+				Name:      "stress_connection",
+				Timestamp: ts.Unix(),
+				Tags:      tags,
+				Fvalues:   fvalues,
+			},
+		},
+	}
+	connection.PostMetric(metric)
+}
+
+type mockAgentsRouter struct {
+}
+
+func (m *mockAgentsRouter) Start(ctx context.Context) {
+}
+
+func (m *mockAgentsRouter) ProcessInstall(install *telemetry_edge.EnvoyInstructionInstall) {
+}
+
+func (m *mockAgentsRouter) ProcessConfigure(configure *telemetry_edge.EnvoyInstructionConfigure) {
+}
+
+func (m *mockAgentsRouter) ProcessTestMonitor(testMonitor *telemetry_edge.EnvoyInstructionTestMonitor) *telemetry_edge.TestMonitorResults {
+	return nil
+}


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

It would be good to profile the Ambassador locally with a controlled number of Envoy connections...and it would be nice to do that without starting a bunch of Envoy processes.

# How

Added a command that simulates any number of Envoys by opening multiple connections with a resource ID each. (The new README section provides even more description.)

## How to test

Start the Ambassador and other usual services and confirm the new command works with the existing `dev/envoy-config-provided.yml` config file.
