### PR TITLE
Added zone as a command-line/env configurable property

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,19 @@ The following is an example configuration file that can be used as a starting po
 ```yaml
 # The identifier of the resource where this Envoy is running
 # The convention is a type:value, but is not required.
+# Command line: --resource-id
+# Environment variable: ENVOY_RESOURCE_ID
 resource_id: "type:value"
+# If set, declares the monitoring zone for remote monitors
+# Command line: --zone
+# Environment variable: ENVOY_ZONE
+zone: ""
 # Additional key:value string pairs that will be included with Envoy attachment.
 labels:
   #environment: production
 # Envoy-token allocated for client certificate retrieval
+# Command line: --auth-token
+# Environment variable: ENVOY_AUTH_TOKEN
 auth_token: ""
 tls:
   auth_service:
@@ -58,6 +66,8 @@ ingest:
     bind: localhost:8194
 agents:
   # Data directory where Envoy stores downloaded agents and write agent configs
+  # Command line: --data-path
+  # Environment variable: ENOVY_DATA_PATH
   dataPath: /var/lib/telemetry-envoy
   # The amount of time an agent is allowed to gracefully stop after a TERM signal. If the
   # timeout is exceeded, then a KILL signal is sent.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,9 @@ func init() {
 	rootCmd.PersistentFlags().String("resource-id", "", "Identifier of the resource where this Envoy is running")
 	viper.BindPFlag(config.ResourceId, rootCmd.PersistentFlags().Lookup("resource-id"))
 
+	rootCmd.PersistentFlags().String("zone", "", "If set, declares the monitoring zone for remote monitors")
+	viper.BindPFlag(config.Zone, rootCmd.PersistentFlags().Lookup("zone"))
+
 	rootCmd.PersistentFlags().String("auth-token", "", "Envoy-token allocated for client certificate retrieval")
 	viper.BindPFlag(config.AuthToken, rootCmd.PersistentFlags().Lookup("auth-token"))
 


### PR DESCRIPTION
# What

While helping with public poller-envoy deployments I realized that
1. zone wasn't documented
2. there wasn't yet the ability to pass the zone via command line or env (latter is preferred for kube deploys)
3. the other env var configurable properties weren't clearly documented