### PR TITLE
Removed old name_template from goreleaser nfpms config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,6 @@ archives:
         format: zip
 nfpms:
   -
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

Apparently as of goreleaser 0.132.0 the `name_template` field in nfpms became `file_name_template`

https://goreleaser.com/customization/#NFPM

# How

Since we were using the same as the default, removed the "renamed" field.

## How to test

Get the latest goreleaser with `brew upgrade goreleaser` and run `make snapshot`.