### PR TITLE
Added ability to do dev image deploy of Envoy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 dist
+.git
+.idea
+*.iml
+k8s-*
+skaffold-*

--- a/cmd/stressconnections.go
+++ b/cmd/stressconnections.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/racker/salus-telemetry-envoy/ambassador"
+	"github.com/racker/salus-telemetry-envoy/config"
 	"github.com/racker/salus-telemetry-protocol/telemetry_edge"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -48,6 +49,10 @@ var stressConnectionsCmd = &cobra.Command{
 			connectionCount := viper.GetInt("stress.connection-count")
 			connectionsDelay := viper.GetDuration("stress.connections-delay")
 			resourcePrefix := viper.GetString("stress.resource-prefix")
+
+			// resource ID gets explicitly overridden in each connection below; however,
+			// the NewEgressConnection constructor still expects the property to be set
+			viper.Set(config.ResourceId, "__unused__")
 
 			connections := make([]ambassador.EgressConnection, connectionCount)
 			for i := 0; i < connectionCount; i++ {

--- a/k8s-stressconn-deploy.yml
+++ b/k8s-stressconn-deploy.yml
@@ -44,7 +44,8 @@ spec:
             - name: ENVOY_STRESS_METRICS_PER_MINUTE
               value: "1"
           envFrom:
-            # provides ENVOY_AUTH_TOKEN
+            # leverage pre-existing secret used for poller-envoy deploy
+            # specifically, provides ENVOY_AUTH_TOKEN
             - secretRef:
                 name: envoy-auth-token
           args:
@@ -55,6 +56,7 @@ spec:
             - mountPath: /etc/config/
               name: envoy-config
       volumes:
+        # leverage pre-existing ConfigMap for poller-envoy deployment
         - name: envoy-config
           configMap:
             name: telemetry-envoy-config

--- a/k8s-stressconn-deploy.yml
+++ b/k8s-stressconn-deploy.yml
@@ -1,0 +1,60 @@
+---
+# Create a headless service to act governing identity of the StatefulSet below
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-stressconn
+spec:
+  selector:
+    app: envoy-stressconn
+  # "None" is what makes it a headless service
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: envoy-stressconn-deployment
+  labels:
+    app: envoy-stressconn
+spec:
+  serviceName: envoy-stressconn
+  replicas: 5
+  selector:
+    matchLabels:
+      app: envoy-stressconn
+  template:
+    metadata:
+      labels:
+        app: envoy-stressconn
+    spec:
+      containers:
+        - name: main
+          image: salus-telemetry-envoy
+          env:
+            # use pod name as resource prefix, which in turn is statefulset name with replica index
+            - name: ENVOY_STRESS_RESOURCE_PREFIX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # keep in mind that overall connection count is this times spec.replicas, above
+            - name: ENVOY_STRESS_CONNECTION_COUNT
+              value: "10"
+            - name: ENVOY_STRESS_CONNECTIONS_DELAY
+              value: "10ms"
+            - name: ENVOY_STRESS_METRICS_PER_MINUTE
+              value: "1"
+          envFrom:
+            # provides ENVOY_AUTH_TOKEN
+            - secretRef:
+                name: envoy-auth-token
+          args:
+            - stress-connections
+            - --config
+            - /etc/config/telemetry-envoy.yaml
+          volumeMounts:
+            - mountPath: /etc/config/
+              name: envoy-config
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: telemetry-envoy-config

--- a/skaffold-stressconn.yaml
+++ b/skaffold-stressconn.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v1
+kind: Config
+build:
+  local: {}
+  artifacts:
+  - image: salus-telemetry-envoy
+deploy:
+  kubectl:
+    manifests:
+      - k8s-stressconn-deploy.yml


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

I wanted to have a way to deploy a one-off, dev image of the Envoy with that "dev" build tag enabled. The Cloud Code IntelliJ plugin along with its use of skaffold ended up solving that pretty nicely since it

- does a local build, tagged by git revision and then by SHA
- manipulates the image reference in the deployment manifest
- runs the deploy
- grabs the output of all the replicas
- and undeploys when stopping

During one of the perf runs the number of metrics processed by ambassador was lower than expected. I realized in the process of that that the "dropped metrics" logs were only debug-level. I made them warning level and a little more informative since I was running the stress-connections mode of envoys without `--debug` enabled.

# How

I'll write up a KB that describes how to setup the IntelliJ run config since it includes some GCP project specifics.

## How to test

See the soon-to-be-KB
